### PR TITLE
Print messages for token auth scenarios

### DIFF
--- a/lib/rspec/buildkite/analytics/uploader.rb
+++ b/lib/rspec/buildkite/analytics/uploader.rb
@@ -141,7 +141,7 @@ module RSpec::Buildkite::Analytics
               end
             else
               request_id = response.to_hash["x-request-id"]
-              puts "Unknown error. Please contact support with this request ID `#{request_id}` support+analytics@buildkite.com."
+              puts "Unknown error. If this error persists, please contact support+analytics@buildkite.com with this request ID `#{request_id}`."
             end
           else
             puts "No Suite API key provided. You can get the API key from your Suite settings page."

--- a/lib/rspec/buildkite/analytics/uploader.rb
+++ b/lib/rspec/buildkite/analytics/uploader.rb
@@ -133,7 +133,7 @@ module RSpec::Buildkite::Analytics
             case response.code
             when "401"
               puts "Invalid Suite API key. Please double check your Suite API key."
-            when "200", "201"
+            when "200"
               json = JSON.parse(response.body)
 
               if (socket_url = json["cable"]) && (channel = json["channel"])

--- a/lib/rspec/buildkite/analytics/uploader.rb
+++ b/lib/rspec/buildkite/analytics/uploader.rb
@@ -130,12 +130,18 @@ module RSpec::Buildkite::Analytics
               puts "Error communicating with the server: #{e.message}"
             end
 
-            if response.is_a?(Net::HTTPSuccess)
+            case response.code
+            when "401"
+              puts "Invalid Suite API key. Please double check your Suite API key."
+            when "200", "201"
               json = JSON.parse(response.body)
 
               if (socket_url = json["cable"]) && (channel = json["channel"])
                 RSpec::Buildkite::Analytics.session = Session.new(socket_url, authorization_header, channel)
               end
+            else
+              request_id = response.to_hash["x-request-id"]
+              puts "Unknown error. Please contact support with this request ID `#{request_id}` support+analytics@buildkite.com."
             end
           else
             puts "No Suite API key provided. You can get the API key from your Suite settings page."

--- a/lib/rspec/buildkite/analytics/uploader.rb
+++ b/lib/rspec/buildkite/analytics/uploader.rb
@@ -137,6 +137,8 @@ module RSpec::Buildkite::Analytics
                 RSpec::Buildkite::Analytics.session = Session.new(socket_url, authorization_header, channel)
               end
             end
+          else
+            puts "No Suite API key provided. You can get the API key from your Suite settings page."
           end
         end
 


### PR DESCRIPTION
This PR prints information for users when:

- No API key was supplied
- Invalid API key supplied
- Unknown errors