### PR TITLE
Relax Active Support constraint and bump to v0.3.1

### DIFF
--- a/lib/rspec/buildkite/analytics/version.rb
+++ b/lib/rspec/buildkite/analytics/version.rb
@@ -3,7 +3,7 @@
 module RSpec
   module Buildkite
     module Analytics
-      VERSION = "0.3.0"
+      VERSION = "0.3.1"
     end
   end
 end

--- a/rspec-buildkite-analytics.gemspec
+++ b/rspec-buildkite-analytics.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
 
-  spec.add_dependency "activesupport", '~> 6.1'
+  spec.add_dependency "activesupport", ">= 5.2", "<= 7.0"
   spec.add_dependency "rspec-core", '~> 3.10'
   spec.add_dependency "rspec-expectations", '~> 3.10'
   spec.add_dependency "websocket", '~> 1.2'


### PR DESCRIPTION
This PR relaxes version constraint of ActiveSupport dependency and bumps gem version to v0.3.1.