### PR TITLE
Require one less env

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,16 @@
 PATH
   remote: .
   specs:
-    rspec-buildkite-analytics (0.2.0)
-      activesupport
-      rspec-core
-      rspec-expectations
-      websocket
+    rspec-buildkite-analytics (0.3.2)
+      activesupport (>= 5.2, <= 7.0)
+      rspec-core (~> 3.10)
+      rspec-expectations (~> 3.10)
+      websocket (~> 1.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.4)
+    activesupport (6.1.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)

--- a/lib/rspec/buildkite/analytics/ci.rb
+++ b/lib/rspec/buildkite/analytics/ci.rb
@@ -4,22 +4,15 @@ require "securerandom"
 
 module RSpec::Buildkite::Analytics::CI
   def self.env
-    if ENV["BUILDKITE"]
-      {
-        "CI" => "buildkite",
-        "key" => ENV["BUILDKITE_BUILD_ID"],
-        "url" => ENV["BUILDKITE_BUILD_URL"],
-        "branch" => ENV["BUILDKITE_BRANCH"],
-        "commit_sha" => ENV["BUILDKITE_COMMIT"],
-        "number" => ENV["BUILDKITE_BUILD_NUMBER"],
-        "job_id" => ENV["BUILDKITE_JOB_ID"],
-        "message" => ENV["BUILDKITE_MESSAGE"]
-      }
-    else
-      {
-        "CI" => nil,
-        "key" => SecureRandom.uuid
-      }
-    end
+    env = {
+      "CI" => ENV["BUILDKITE"] ? "buildkite" : nil,
+      "key" => ENV["BUILDKITE_BUILD_ID"] || SecureRandom.uuid,
+      "url" => ENV["BUILDKITE_BUILD_URL"],
+      "branch" => ENV["BUILDKITE_BRANCH"],
+      "commit_sha" => ENV["BUILDKITE_COMMIT"],
+      "number" => ENV["BUILDKITE_BUILD_NUMBER"],
+      "job_id" => ENV["BUILDKITE_JOB_ID"],
+      "message" => ENV["BUILDKITE_MESSAGE"]
+    }
   end
 end

--- a/lib/rspec/buildkite/analytics/version.rb
+++ b/lib/rspec/buildkite/analytics/version.rb
@@ -3,7 +3,7 @@
 module RSpec
   module Buildkite
     module Analytics
-      VERSION = "0.3.1"
+      VERSION = "0.3.2"
     end
   end
 end

--- a/spec/analytics/ci_spec.rb
+++ b/spec/analytics/ci_spec.rb
@@ -18,6 +18,13 @@ RSpec.describe "RSpec::Buildkite::Analytics::CI" do
 
     it "BUILDKITE ENVs not set" do
       fake_env("BUILDKITE", nil)
+      fake_env("BUILDKITE_BUILD_ID", nil)
+      fake_env("BUILDKITE_BUILD_URL", nil)
+      fake_env("BUILDKITE_BRANCH", nil)
+      fake_env("BUILDKITE_COMMIT", nil)
+      fake_env("BUILDKITE_BUILD_NUMBER", nil)
+      fake_env("BUILDKITE_JOB_ID", nil)
+      fake_env("BUILDKITE_MESSAGE", nil)
       allow(SecureRandom).to receive(:uuid) { "845ac829-2ab3-4bbb-9e24-3529755a6d37" }
       result = RSpec::Buildkite::Analytics::CI.env
 

--- a/spec/analytics/ci_spec.rb
+++ b/spec/analytics/ci_spec.rb
@@ -23,7 +23,13 @@ RSpec.describe "RSpec::Buildkite::Analytics::CI" do
 
       expect(result).to match({
         "CI" => nil,
-        "key" => "845ac829-2ab3-4bbb-9e24-3529755a6d37"
+        "key" => "845ac829-2ab3-4bbb-9e24-3529755a6d37",
+        "url" => nil,
+        "branch" => nil,
+        "commit_sha" => nil,
+        "number" => nil,
+        "job_id" => nil,
+        "message" => nil
       })
     end
 

--- a/spec/analytics/ci_spec.rb
+++ b/spec/analytics/ci_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "RSpec::Buildkite::Analytics::CI" do
       allow(ENV).to receive(:[]).and_call_original
     end
 
-    it "not running on Buildkite" do
+    it "BUILDKITE ENVs not set" do
       fake_env("BUILDKITE", nil)
       allow(SecureRandom).to receive(:uuid) { "845ac829-2ab3-4bbb-9e24-3529755a6d37" }
       result = RSpec::Buildkite::Analytics::CI.env


### PR DESCRIPTION
We currently require two ENVs `BUILDKITE` and `BUILDKITE_BUILD_ID` to make Runs work (that Jobs inside a Build will be filed under one Run). This PR changes to only require `BUILDKITE_BUILD_ID`.