### PR TITLE
Add a dependency version for openssl

### DIFF
--- a/rspec-buildkite-analytics.gemspec
+++ b/rspec-buildkite-analytics.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rspec-core", '~> 3.10'
   spec.add_dependency "rspec-expectations", '~> 3.10'
   spec.add_dependency "websocket", '~> 1.2'
+  spec.add_dependency "openssl", '>= 2.2.1'
 end


### PR DESCRIPTION
I made this `>=2.2.1` cos the bugfix is only in the releases `2.1.3` and `2.2.1` 
<img width="1237" alt="Screen Shot 2021-10-20 at 11 50 57 AM" src="https://user-images.githubusercontent.com/4241125/138001446-a7302ce1-f2d0-4594-9d9b-775707f4fd10.png">

I then bundled buildkite/buildkite locally with the gem and ran `BUILDKITE_ANALYTICS_TOKEN=local rspec spec/models` and all executions were created as expected, so I think this will be fine 🤞