### PR TITLE
Catch IndexError

### DIFF
--- a/lib/rspec/buildkite/analytics/socket_connection.rb
+++ b/lib/rspec/buildkite/analytics/socket_connection.rb
@@ -82,6 +82,16 @@ module RSpec::Buildkite::Analytics
         end
       rescue IOError
         # This is fine to ignore
+      rescue IndexError
+        # I don't like that we're doing this but I think it's the best of the options
+        #
+        # This relates to this issue https://github.com/ruby/openssl/issues/452
+        # A fix for it has been released but the repercussions of overriding
+        # the OpenSSL version in the stdlib seem worse than catching this error here.
+        if @socket
+          @session.disconnected(self)
+          disconnect
+        end
       end
     end
 
@@ -96,6 +106,16 @@ module RSpec::Buildkite::Analytics
       return unless @socket
       @session.disconnected(self)
       disconnect
+    rescue IndexError
+      # I don't like that we're doing this but I think it's the best of the options
+      #
+      # This relates to this issue https://github.com/ruby/openssl/issues/452
+      # A fix for it has been released but the repercussions of overriding
+      # the OpenSSL version in the stdlib seem worse than catching this error here.
+      if @socket
+        @session.disconnected(self)
+        disconnect
+      end
     end
 
     def close

--- a/spec/analytics/socket_connection_spec.rb
+++ b/spec/analytics/socket_connection_spec.rb
@@ -47,5 +47,21 @@ RSpec.describe "RSpec::Buildkite::Analytics::SocketConnection" do
       expect(session_double).to  receive(:disconnected)
       socket_connection.transmit("hi")
     end
+
+    it "calls disconnected if it gets an IndexError" do
+      write_call_count = 0
+      allow(ssl_socket_double).to receive(:write) {
+        write_call_count += 1
+        # the first write is part of the handshaking process, so let it succeed
+        if write_call_count == 1
+          nil
+        else
+          raise IndexError
+        end
+      }
+
+      expect(session_double).to  receive(:disconnected)
+      socket_connection.transmit("hi")
+    end
   end
 end


### PR DESCRIPTION
On occasion we're seeing the analytics gem hard fail (i.e. makes the tests fail) with `IndexError`. It's not great. Let's catch the error and trigger our reconnect flow. Alternate approach to #54. 

The thing I'm not sure about: if an `IndexError` is thrown in other parts of the application that includes this gem, will it get caught here??? 