### PR TITLE
Add debug mode

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rspec-buildkite-analytics (0.3.6)
+    rspec-buildkite-analytics (0.4.0)
       activesupport (>= 5.2, <= 7.0)
       rspec-core (~> 3.10)
       rspec-expectations (~> 3.10)

--- a/lib/rspec/buildkite/analytics.rb
+++ b/lib/rspec/buildkite/analytics.rb
@@ -15,11 +15,15 @@ module RSpec::Buildkite::Analytics
     attr_accessor :url
     attr_accessor :uploader
     attr_accessor :session
+    attr_accessor :debug_enabled
+    attr_accessor :debug_filepath
   end
 
-  def self.configure(token: nil, url: nil)
+  def self.configure(token: nil, url: nil, debug_enabled: false, debug_filepath: nil)
     self.api_token = token || ENV["BUILDKITE_ANALYTICS_TOKEN"]
     self.url = url || DEFAULT_URL
+    self.debug_enabled = debug_enabled || !!(ENV["BUILDKITE_ANALYTICS_DEBUG_ENABLED"])
+    self.debug_filepath = debug_filepath || ENV["BUILDKITE_ANALYTICS_DEBUG_FILEPATH"]
 
     require_relative "analytics/uploader"
 

--- a/lib/rspec/buildkite/analytics/ci.rb
+++ b/lib/rspec/buildkite/analytics/ci.rb
@@ -13,12 +13,14 @@ module RSpec::Buildkite::Analytics::CI
         "commit_sha" => ENV["BUILDKITE_COMMIT"],
         "number" => ENV["BUILDKITE_BUILD_NUMBER"],
         "job_id" => ENV["BUILDKITE_JOB_ID"],
-        "message" => ENV["BUILDKITE_MESSAGE"]
+        "message" => ENV["BUILDKITE_MESSAGE"],
+        "debug" => ENV["BUILDKITE_ANALYTICS_DEBUG_ENABLED"]
       }
     else
       {
         "CI" => nil,
-        "key" => SecureRandom.uuid
+        "key" => SecureRandom.uuid,
+        "debug" => ENV["BUILDKITE_ANALYTICS_DEBUG_ENABLED"]
       }
     end
   end

--- a/lib/rspec/buildkite/analytics/reporter.rb
+++ b/lib/rspec/buildkite/analytics/reporter.rb
@@ -1,6 +1,6 @@
 module RSpec::Buildkite::Analytics
   class Reporter
-    RSpec::Core::Formatters.register self, :example_passed, :example_failed, :example_pending
+    RSpec::Core::Formatters.register self, :example_passed, :example_failed, :example_pending, :dump_summary
 
     attr_reader :output
 
@@ -20,6 +20,30 @@ module RSpec::Buildkite::Analytics
       end
     end
 
+    def dump_summary(notification)
+      if RSpec::Buildkite::Analytics.session.present?
+        examples_count = {
+          examples: notification.examples.count,
+          failed: notification.failed_examples.count,
+          pending: notification.pending_examples.count,
+          errors_outside_examples: notification.errors_outside_of_examples_count
+        }
+
+        RSpec::Buildkite::Analytics.session.close(examples_count)
+
+        # Write the debug file, if debug mode is enabled
+        if RSpec::Buildkite::Analytics.debug_enabled
+          filename = "#{RSpec::Buildkite::Analytics.debug_filepath}/bk-analytics-#{DateTime.current.strftime("%F-%R:%S")}-#{ENV["BUILDKITE_JOB_ID"]}.log.gz"
+
+          File.open(filename, "wb") do |f|
+            gz = Zlib::GzipWriter.new(f)
+            gz.puts(RSpec::Buildkite::Analytics.session.logger.to_array)
+            gz.close
+          end
+        end
+      end
+    end
+ 
     alias_method :example_passed, :handle_example
     alias_method :example_failed, :handle_example
     alias_method :example_pending, :handle_example

--- a/lib/rspec/buildkite/analytics/session.rb
+++ b/lib/rspec/buildkite/analytics/session.rb
@@ -87,8 +87,9 @@ module RSpec::Buildkite::Analytics
       retransmit
     end
 
-    def close()
+    def close(examples_count)
       @closing = true
+      @examples_count = examples_count
       @logger.write("closing socket connection")
 
       # Because the server only sends us confirmations after every 10mb of
@@ -232,7 +233,8 @@ module RSpec::Buildkite::Analytics
         "identifier" => @channel,
         "command" => "message",
         "data" => {
-          "action" => "end_of_transmission"
+          "action" => "end_of_transmission",
+          "examples_count" => @examples_count.to_json
         }.to_json
       })
 

--- a/lib/rspec/buildkite/analytics/uploader.rb
+++ b/lib/rspec/buildkite/analytics/uploader.rb
@@ -162,23 +162,6 @@ module RSpec::Buildkite::Analytics
           trace = RSpec::Buildkite::Analytics::Uploader::Trace.new(example, tracer.history)
           RSpec::Buildkite::Analytics.uploader.traces << trace
         end
-
-        config.after(:suite) do
-          if RSpec::Buildkite::Analytics.session.present?
-            RSpec::Buildkite::Analytics.session.close
-
-            # Write the debug file, if debug mode is enabled
-            if RSpec::Buildkite::Analytics.debug_enabled
-              filename = "#{RSpec::Buildkite::Analytics.debug_filepath}/bk-analytics-#{DateTime.current.strftime("%F-%R:%S")}-#{ENV["BUILDKITE_JOB_ID"]}.log.gz"
-
-              File.open(filename, "wb") do |f|
-                gz = Zlib::GzipWriter.new(f)
-                gz.puts(RSpec::Buildkite::Analytics.session.logger.to_array)
-                gz.close
-              end
-            end
-          end
-        end
       end
 
       RSpec::Buildkite::Analytics::Network.configure

--- a/lib/rspec/buildkite/analytics/version.rb
+++ b/lib/rspec/buildkite/analytics/version.rb
@@ -3,7 +3,7 @@
 module RSpec
   module Buildkite
     module Analytics
-      VERSION = "0.3.6"
+      VERSION = "0.4.0"
     end
   end
 end

--- a/spec/analytics/ci_spec.rb
+++ b/spec/analytics/ci_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "RSpec::Buildkite::Analytics::CI" do
     let(:number) { "4242" }
     let(:job_id) { "j3459ui2-l0dk-4829-i029-97999t1e09d6" }
     let(:message) { "Merge pull request #1 from buildkite/branch\n commit title" }
+    let(:debug) { "true" }
 
     before do
       allow(ENV).to receive(:[]).and_call_original
@@ -22,6 +23,7 @@ RSpec.describe "RSpec::Buildkite::Analytics::CI" do
       fake_env("BUILDKITE_BUILD_NUMBER", number)
       fake_env("BUILDKITE_JOB_ID", job_id)
       fake_env("BUILDKITE_MESSAGE", message)
+      fake_env("BUILDKITE_ANALYTICS_DEBUG_ENABLED", debug)
     end
 
     context "when BUILDKITE_BUILD_ID is set" do
@@ -40,7 +42,8 @@ RSpec.describe "RSpec::Buildkite::Analytics::CI" do
           "commit_sha" => commit_sha,
           "number" => number,
           "job_id" => job_id,
-          "message" => message
+          "message" => message,
+          "debug" => debug
         })
       end
     end
@@ -52,12 +55,13 @@ RSpec.describe "RSpec::Buildkite::Analytics::CI" do
         fake_env("BUILDKITE_BUILD_ID", nil)
       end
 
-      it "only returns the key" do
+      it "returns the key and debug" do
         result = RSpec::Buildkite::Analytics::CI.env
 
         expect(result).to match({
           "CI" => nil,
-          "key" => "845ac829-2ab3-4bbb-9e24-3529755a6d37"
+          "key" => "845ac829-2ab3-4bbb-9e24-3529755a6d37",
+          "debug" => debug
         })
       end
     end

--- a/spec/analytics/socket_connection_spec.rb
+++ b/spec/analytics/socket_connection_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe "RSpec::Buildkite::Analytics::SocketConnection" do
 
     allow(WebSocket::Frame::Outgoing::Client).to receive(:new).and_return(frame_double)
     allow(frame_double).to receive(:to_s).and_return("hi")
+
+    allow(session_double).to receive_message_chain("logger.write").with(anything).and_return(nil)
   end
 
   describe "#transmit" do
@@ -44,7 +46,7 @@ RSpec.describe "RSpec::Buildkite::Analytics::SocketConnection" do
         end
       }
 
-      expect(session_double).to  receive(:disconnected)
+      expect(session_double).to receive(:disconnected)
       socket_connection.transmit("hi")
     end
 
@@ -60,7 +62,7 @@ RSpec.describe "RSpec::Buildkite::Analytics::SocketConnection" do
         end
       }
 
-      expect(session_double).to  receive(:disconnected)
+      expect(session_double).to receive(:disconnected)
       socket_connection.transmit("hi")
     end
   end


### PR DESCRIPTION
This PR introduces a debug mode to the collector, which creates a text file with debug information that is uploaded to the job as an artifact. This was done because we realised that it wasn't possible with Datadog to exhaustively log the requests going through the socket, and it made debugging errors difficult. Hence, saving the relevant info to a text file, and also [adding logging on Buildkite](https://github.com/buildkite/buildkite/pull/7365) so we can build a complete picture of what has/hasn't been received. 

I have added two new environment params, `BUILDKITE_ANALYTICS_DEBUG_ENABLED` and `BUILDKITE_ANALYTICS_DEBUG_FILEPATH` which configure the enabling of debug mode, and the filepath to save the artifact at. I created a custom lightweight Logger class to facilitate the logging, it needed to be threadsafe so it's using a `Queue` object to store the log lines. 

Another change in this PR is that I've changed the payload of the `end_of_transmission` message to include some counts of how many examples were run, and how many failed. This is so that in the future we can compare these numbers against the number of executions that were actually created in each upload. Because there's going to be a lot of log files, I wanted there to be some mechanism where we could winnow down to log files that we're interested in, rather than just hoping that there's interesting info. 

To achieve the above, I had to move some of the code in the `after(:suite)` hook into a formatter instead, as the example counts I wanted weren't available in the after suite callback. 

I tested this PR by bundling locally with the changes in [this PR](https://github.com/buildkite/buildkite/pull/7365)