### PR TITLE
Avoid activesupport when generating debugging timestamps

### DIFF
--- a/lib/rspec/buildkite/analytics/reporter.rb
+++ b/lib/rspec/buildkite/analytics/reporter.rb
@@ -1,3 +1,5 @@
+require "time"
+
 module RSpec::Buildkite::Analytics
   class Reporter
     RSpec::Core::Formatters.register self, :example_passed, :example_failed, :example_pending, :dump_summary
@@ -33,7 +35,7 @@ module RSpec::Buildkite::Analytics
 
         # Write the debug file, if debug mode is enabled
         if RSpec::Buildkite::Analytics.debug_enabled
-          filename = "#{RSpec::Buildkite::Analytics.debug_filepath}/bk-analytics-#{DateTime.current.strftime("%F-%R:%S")}-#{ENV["BUILDKITE_JOB_ID"]}.log.gz"
+          filename = "#{RSpec::Buildkite::Analytics.debug_filepath}/bk-analytics-#{Time.now.strftime("%F-%R:%S")}-#{ENV["BUILDKITE_JOB_ID"]}.log.gz"
 
           File.open(filename, "wb") do |f|
             gz = Zlib::GzipWriter.new(f)


### PR DESCRIPTION
I believe `DateTime.current` is an activesupport-ism.

This gem does depend on activesupport so in theory we could use `DateTime.current`, however when I was running v0.4.0 with my non-rails rspec project I was getting:

```ruby
NameError: uninitialized constant RSpec::Buildkite::Analytics::Reporter::DateTime
Did you mean?  DateAndTime
  /.../rspec-buildkite-analytics/lib/rspec/buildkite/analytics/reporter.rb:36:in `dump_summary'
```

I think we could fix this by adding an explicit `require "datetime"` to the file. However if we're going to do that, we may as well stick to the stdlib and use plain `Time.now` when generating a timestamp.