### PR TITLE
Use the system tmpdir as a default location for debugging logs

### DIFF
--- a/lib/rspec/buildkite/analytics.rb
+++ b/lib/rspec/buildkite/analytics.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "timeout"
+require "tmpdir"
 
 require_relative "analytics/version"
 
@@ -23,7 +24,7 @@ module RSpec::Buildkite::Analytics
     self.api_token = token || ENV["BUILDKITE_ANALYTICS_TOKEN"]
     self.url = url || DEFAULT_URL
     self.debug_enabled = debug_enabled || !!(ENV["BUILDKITE_ANALYTICS_DEBUG_ENABLED"])
-    self.debug_filepath = debug_filepath || ENV["BUILDKITE_ANALYTICS_DEBUG_FILEPATH"]
+    self.debug_filepath = debug_filepath || ENV["BUILDKITE_ANALYTICS_DEBUG_FILEPATH"] || Dir.tmpdir
 
     require_relative "analytics/uploader"
 


### PR DESCRIPTION
I tried using the debugging feature added in 0.4.0, and got a file permissions exception:

```
    $ BUILDKITE_ANALYTICS_DEBUG_ENABLED=true be rspec spec/integration_spec.rb:16
    Run options: include {:locations=>{"./spec/integration_spec.rb"=>[16]}}
    .

    Finished in 6.03 seconds (files took 0.21893 seconds to load)
    1 example, 0 failures

    bundler: failed to load command: rspec (/home/jh/.rbenv/versions/2.7.2/bin/rspec)
    Errno::EACCES: Permission denied @ rb_sysopen - /bk-analytics-2021-11-08-00:28:15-.log.gz
      /.../rspec-buildkite-analytics/lib/rspec/buildkite/analytics/reporter.rb:40:in `initialize'
      /.../rspec-buildkite-analytics/lib/rspec/buildkite/analytics/reporter.rb:40:in `open'
      /.../rspec-buildkite-analytics/lib/rspec/buildkite/analytics/reporter.rb:40:in `dump_summary'
      /home/jh/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rspec-core-3.10.1/lib/rspec/core/reporter.rb:209:in `block in notify'
```

I didn't realise that I needed to set the BUILDKITE_ANALYTICS_DEBUG_FILEPATH env var as well, and without it the gem wants to write the file to my root directory.

I thought it might be nice to make BUILDKITE_ANALYTICS_DEBUG_FILEPATH optional, and default to the system tmpdir if no other path is provided. In my local environment at least, that's a useful default. Presumably in a CI environment (where this gem is likely to be much more commonly used) we'd still recommend folks set BUILDKITE_ANALYTICS_DEBUG_FILEPATH.