### PR TITLE
Move send to background thread

### DIFF
--- a/lib/rspec/buildkite/analytics/session.rb
+++ b/lib/rspec/buildkite/analytics/session.rb
@@ -35,7 +35,7 @@ module RSpec::Buildkite::Analytics
     attr_reader :logger
 
     def initialize(url, authorization_header, channel)
-      @queue = Queue.new
+      @establish_subscription_queue = Queue.new
       @channel = channel
 
       @unconfirmed_idents = {}
@@ -121,7 +121,7 @@ module RSpec::Buildkite::Analytics
       when "welcome", "confirm_subscription"
         # Push these two messages onto the queue, so that we block on waiting for the
         # initializing phase to complete
-        @queue.push(data)
+        @establish_subscription_queue.push(data)
       @logger.write("received #{data['type']}")
       when "reject_subscription"
         @logger.write("received rejected_subscription")
@@ -181,7 +181,7 @@ module RSpec::Buildkite::Analytics
 
     def pop_with_timeout(message_type)
       Timeout.timeout(30, RSpec::Buildkite::Analytics::TimeoutError, "Timeout: Waited 30 seconds for #{message_type}") do
-        @queue.pop
+        @establish_subscription_queue.pop
       end
     end
 

--- a/lib/rspec/buildkite/analytics/socket_connection.rb
+++ b/lib/rspec/buildkite/analytics/socket_connection.rb
@@ -110,6 +110,7 @@ module RSpec::Buildkite::Analytics
       @socket.write(frame.to_s)
     rescue Errno::EPIPE, Errno::ECONNRESET, OpenSSL::SSL::SSLError => e
       return unless @socket
+      return if type == :close
       @session.logger.write("got #{e}, attempting disconnected flow")
       @session.disconnected(self)
       disconnect

--- a/lib/rspec/buildkite/analytics/tracer.rb
+++ b/lib/rspec/buildkite/analytics/tracer.rb
@@ -13,15 +13,15 @@ module RSpec::Buildkite::Analytics
         @children = []
       end
 
-      def as_json
+      def as_hash
         {
           section: section,
           start_at: start_at,
           end_at: end_at,
           duration: end_at - start_at,
           detail: detail,
-          children: children.map(&:as_json),
-        }
+          children: children.map(&:as_hash),
+        }.with_indifferent_access
       end
     end
 
@@ -57,7 +57,7 @@ module RSpec::Buildkite::Analytics
     end
 
     def history
-      @top.as_json
+      @top.as_hash
     end
   end
 end

--- a/lib/rspec/buildkite/analytics/uploader.rb
+++ b/lib/rspec/buildkite/analytics/uploader.rb
@@ -48,7 +48,7 @@ module RSpec::Buildkite::Analytics
         end
       end
 
-      def as_json
+      def as_hash
         {
           id: @id,
           scope: example.example_group.metadata[:full_description],
@@ -59,7 +59,7 @@ module RSpec::Buildkite::Analytics
           result: result_state,
           failure: failure_message,
           history: history,
-        }
+        }.with_indifferent_access
       end
 
       private

--- a/lib/rspec/buildkite/analytics/uploader.rb
+++ b/lib/rspec/buildkite/analytics/uploader.rb
@@ -141,7 +141,7 @@ module RSpec::Buildkite::Analytics
               end
             else
               request_id = response.to_hash["x-request-id"]
-              puts "Buildkite Test Analytics: Unknown error. If this error persists, please contact support+analytics@buildkite.com with this request ID `#{request_id}`."
+              puts "rspec-buildkite-analytics could not establish an initial connection with Buildkite. You may be missing some data for this test suite, please contact support."
             end
           else
             puts "Buildkite Test Analytics: No Suite API key provided. You can get the API key from your Suite settings page."

--- a/spec/analytics/session_spec.rb
+++ b/spec/analytics/session_spec.rb
@@ -120,15 +120,15 @@ RSpec.describe "RSpec::Buildkite::Analytics::Session" do
   describe "#write_result" do
     let(:fake_trace) { instance_double("RSpec::Buildkite::Analytics::Uploader::Trace") }
     let(:fake_trace_id) { "33569b01-4180-4416-9631-c25d370a4c96" }
-    let(:trace_json) do
+    let(:trace_hash) do
       {
         id: fake_trace_id,
         identifier: "./spec/analytics/session_spec.rb[1:2]"
-      }.to_json
+      }
     end
 
     before do
-      allow(fake_trace).to receive(:as_json).and_return(trace_json)
+      allow(fake_trace).to receive(:as_hash).and_return(trace_hash)
       allow(fake_trace).to receive(:id).and_return(fake_trace_id)
     end
 
@@ -383,7 +383,7 @@ RSpec.describe "RSpec::Buildkite::Analytics::Session" do
 
       expect { session.disconnected(socket_double) }.to raise_error(RSpec::Buildkite::Analytics::SocketConnection::SocketError)
 
-      # This expectation is for 5 times because the socket connects initially, then it has 3 retries, then on the fourth retry the error is thrown
+      # This expectation is for 5 times because the socket connects initially, then it has 2 retries, then on the fourth retry the error is thrown
       expect(RSpec::Buildkite::Analytics::SocketConnection).to have_received(:new).exactly(5).times
     end
   end


### PR DESCRIPTION
I've added another thread to this gem but I swear it hasn't gotten more complicated 🙈

The major change here is that there's a new send queue for outbound messages. When an rspec test is finished, the results from that test are pushed into the send queue, rather than being written to the socket immediately. Instead, a new `write_thread` is instantiated that waits for messages to appear on the send queue, and sends them through the socket. This change means that reading and writing from the socket happen entirely in the two background threads, so any failures in them don't affect the main thread which is running the rspec tests. If the socket connection is broken for any reason, the existing reconnection + retransmission logic handles this. 

When the rspec tests have finished, our existing `session.close` behaviour was waiting up to 75 seconds for the last `confirm` message to be sent by the server. Since sending through the socket is really fast, any build up of messages (because of disconnects) can catch up in this time and then we can finish and close out the session as normal. Added some logic around only queueing one `eot` message at a time, as we don't know when things are sent anymore. 

Unit testing for this has gotten a little more complicated due to the extra threads, so I haven't really made many modifications to this. Instead I manually tested these cases: 
- works when an initial connection to buildkite can't be established (no executions + s3 data in this scenario)
- works and all executions + s3 data is persisted when connection to buildkite can be established (tested both for a small test run, and one that spans multiple upload parts)
- works and all executions + s3 data is persisted when a reconnection to buildkite is successful 
- doesn't explode if reconnection to buildkite is unsuccessful (doesn't affect the rspec test running, but it does wait for full length of timeout before closing the session)

~~Also found [this bug](https://github.com/buildkite/buildkite/pull/7454) while testing~~
