### PR TITLE
Send failure reasons for failed executions

### DIFF
--- a/lib/rspec/buildkite/analytics/uploader.rb
+++ b/lib/rspec/buildkite/analytics/uploader.rb
@@ -22,22 +22,15 @@ require "securerandom"
 module RSpec::Buildkite::Analytics
   class Uploader
     class Trace
-      attr_accessor :example
+      attr_accessor :example, :failure_reason, :failure_expanded
       attr_reader :id, :history
 
       def initialize(example, history)
         @id = SecureRandom.uuid
         @example = example
         @history = history
-      end
-
-      def failure_message
-        case example.exception
-        when RSpec::Expectations::ExpectationNotMetError
-          example.exception.message
-        when Exception
-          "#{example.exception.class}: #{example.exception.message}"
-        end
+        @failure_reason = nil
+        @failure_expanded = []
       end
 
       def result_state
@@ -57,9 +50,10 @@ module RSpec::Buildkite::Analytics
           location: example.location,
           file_name: generate_file_name(example),
           result: result_state,
-          failure: failure_message,
+          failure_reason: failure_reason,
+          failure_expanded: failure_expanded,
           history: history,
-        }.with_indifferent_access
+        }.with_indifferent_access.compact
       end
 
       private


### PR DESCRIPTION
This PR adds support for sending through two new pieces of data `failure_reason` and `failure_expanded`. There was a previous key called `failure_message` that I've removed as we never did anything with it. The content of this key was pretty much what is in `failure_reason`. 

`failure_reason` is a one line summary of the failure, e.g. `"Failure/Error: expect(true).to eq false"`. `failure_expanded` is an array, with each element being an array of `message_lines` and `backtrace` so that these elements can be formatted separately in the front end. 

I wasn't sure if it was worth adding a test for this without basically mocking out all of RSpec so I didn't 🤷‍♀️ I tested this with the three types of exception we'd expect, there's ones for failed expectation, multiple failed expectations and errors. 