### PR TITLE
Send format

### DIFF
--- a/lib/rspec/buildkite/analytics/uploader.rb
+++ b/lib/rspec/buildkite/analytics/uploader.rb
@@ -121,7 +121,8 @@ module RSpec::Buildkite::Analytics
               "Content-Type" => "application/json",
             })
             contact.body = {
-              run_env: CI.env
+              run_env: CI.env,
+              format: "websocket"
             }.to_json
 
             response = begin


### PR DESCRIPTION
New `format` param was introduced in [buildkite PR#7525](https://github.com/buildkite/buildkite/pull/7525) to support uploads not just from this collector, send this value through so [buildkite doesn't have to deal with it being null anymore](https://github.com/buildkite/buildkite/pull/7525/files#diff-f1b550c16dfbb29caae2f9eebd8c9fbda11129ab77dde799a2097175a91b700dR42)