### PR TITLE
Even better failure reasons

### DIFF
--- a/lib/rspec/buildkite/analytics/reporter.rb
+++ b/lib/rspec/buildkite/analytics/reporter.rb
@@ -53,10 +53,15 @@ module RSpec::Buildkite::Analytics
 
     private
 
+    MULTIPLE_ERRORS = [
+      RSpec::Expectations::MultipleExpectationsNotMetError,
+      RSpec::Core::MultipleExceptionError
+    ]
+
     def failure_info(notification)
       failure_expanded = []
 
-      if notification.exception.class == RSpec::Expectations::MultipleExpectationsNotMetError
+      if RSpec::Buildkite::Analytics::Reporter::MULTIPLE_ERRORS.include?(notification.exception.class)
         failure_reason = notification.exception.summary
         notification.exception.all_exceptions.each do |exception|
           # an example with multiple failures doesn't give us a

--- a/lib/rspec/buildkite/analytics/reporter.rb
+++ b/lib/rspec/buildkite/analytics/reporter.rb
@@ -76,10 +76,8 @@ module RSpec::Buildkite::Analytics
           }
         end
       else
-        failure_reason = strip_diff_colors(notification.colorized_message_lines[0])
-
-        # the second line is always whitespace padding
-        message_lines = notification.colorized_message_lines[2..]
+        message_lines = notification.colorized_message_lines
+        failure_reason = strip_diff_colors(message_lines.shift)
 
         failure_expanded << {
           expanded:  format_message_lines(message_lines),
@@ -92,6 +90,8 @@ module RSpec::Buildkite::Analytics
 
     def format_message_lines(message_lines)
       message_lines.map! { |l| strip_diff_colors(l) }
+      # the first line is sometimes blank, depending on the error reported
+      message_lines.shift if message_lines.first.blank?
       # the last line is sometimes blank, depending on the error reported
       message_lines.pop if message_lines.last.blank?
       message_lines

--- a/lib/rspec/buildkite/analytics/version.rb
+++ b/lib/rspec/buildkite/analytics/version.rb
@@ -3,7 +3,7 @@
 module RSpec
   module Buildkite
     module Analytics
-      VERSION = "0.6.0"
+      VERSION = "0.6.1"
     end
   end
 end


### PR DESCRIPTION
In [the build](https://buildkite.com/buildkite/buildkite/builds/39934#87993c00-af14-4992-bdf3-2b766de430dc) for my [gem bump PR](https://github.com/buildkite/buildkite/pull/7621) there was a failing test so I thought "oh great I can test the new API", and then I realised that Capybara output is formatted differently 🤦‍♀️ 

![Screen Shot 2021-12-09 at 11 24 10 AM](https://user-images.githubusercontent.com/4241125/145319188-2c688d22-9d09-4837-931b-83c297abfe6b.png)

And then I also found a new type of multiple error exception while testing this change lol