### PR TITLE
Handle scenario when we got no response

### DIFF
--- a/lib/rspec/buildkite/analytics/uploader.rb
+++ b/lib/rspec/buildkite/analytics/uploader.rb
@@ -125,6 +125,8 @@ module RSpec::Buildkite::Analytics
               puts "Buildkite Test Analytics: Error communicating with the server: #{e.message}"
             end
 
+            return unless response
+
             case response.code
             when "401"
               puts "Buildkite Test Analytics: Invalid Suite API key. Please double check your Suite API key."


### PR DESCRIPTION
An early return to avoid calling methods on no response code paths.