### PR TITLE
Add retries to initial connection

### DIFF
--- a/lib/rspec/buildkite/analytics/session.rb
+++ b/lib/rspec/buildkite/analytics/session.rb
@@ -58,9 +58,9 @@ module RSpec::Buildkite::Analytics
         reconnection_count += 1
         connect
       rescue TimeoutError, InitialConnectionFailure => e
-        @logger.write("failed initial connection attempt #{reconnection_count} due to #{e}")
+        @logger.write("rspec-buildkite-analytics could not establish an initial connection with Buildkite due to #{e}. Attempting retry #{reconnection_count} of #{MAX_RECONNECTION_ATTEMPTS}...")
         if reconnection_count > MAX_RECONNECTION_ATTEMPTS
-          $stderr.puts "rspec-buildkite-analytics could not establish an initial connection with Buildkite due to #{e.message}. You may be missing some data for this test suite, please contact support if this issue persists."
+          $stderr.puts "rspec-buildkite-analytics could not establish an initial connection with Buildkite due to #{e.message} after #{MAX_RECONNECTION_ATTEMPTS} attempts. You may be missing some data for this test suite, please contact support if this issue persists."
         else
           sleep(WAIT_BETWEEN_RECONNECTIONS)
           @logger.write("retrying reconnection")

--- a/lib/rspec/buildkite/analytics/session.rb
+++ b/lib/rspec/buildkite/analytics/session.rb
@@ -170,8 +170,10 @@ module RSpec::Buildkite::Analytics
       wait_for_confirm
 
       @logger.write("connected")
+    end
 
-      # As this connect method can be called multiple times in the
+    def init_write_thread
+      # As this method can be called multiple times in the
       # reconnection process, kill prev write threads (if any) before
       # setting up the new one
       @write_thread&.kill

--- a/lib/rspec/buildkite/analytics/session.rb
+++ b/lib/rspec/buildkite/analytics/session.rb
@@ -76,7 +76,8 @@ module RSpec::Buildkite::Analytics
         begin
           reconnection_count += 1
           connect
-        rescue SocketConnection::HandshakeError, RejectedSubscription, TimeoutError, SocketConnection::SocketError => e
+          init_write_thread
+        rescue SocketConnection::HandshakeError, RejectedSubscription, TimeoutError, InitialConnectionFailure, SocketConnection::SocketError => e
           @logger.write("failed reconnection attempt #{reconnection_count} due to #{e}")
           if reconnection_count > MAX_RECONNECTION_ATTEMPTS
             $stderr.puts "rspec-buildkite-analytics experienced a disconnection and could not reconnect to Buildkite due to #{e.message}. Please contact support."


### PR DESCRIPTION
Enough customers reported seeing the "Timeout: waited 30s for welcome" error during the initial connection process that I thought it'd be good to put retries around this, like we do in the disconnect. 

My first thought was to refactor the reconnection code to be shared, but realised that this wasn't going to work as the reconnection code needs a mutex around reconnection attempts because we're not sure which thread will be doing the reconnection. Instead, I refactored the `connect` method to remove the instantiation of the write thread, so the `connect` now is just doing the ActionCable handshake business. This also means that we don't need to worry about locking in the initial connection phase, as the write thread doesn't exists yet, and we have a smaller set of errors that we expect during initial connection. 

Have integration tested to see that reconnection + failed initial connection still works. 