### PR TITLE
Store collector version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rspec-buildkite-analytics (0.6.2)
+    rspec-buildkite-analytics (0.6.3)
       activesupport (>= 5.2, <= 7.0)
       rspec-core (~> 3.10)
       rspec-expectations (~> 3.10)

--- a/lib/rspec/buildkite/analytics/ci.rb
+++ b/lib/rspec/buildkite/analytics/ci.rb
@@ -15,14 +15,16 @@ module RSpec::Buildkite::Analytics::CI
         "job_id" => ENV["BUILDKITE_JOB_ID"],
         "message" => ENV["BUILDKITE_MESSAGE"],
         "debug" => ENV["BUILDKITE_ANALYTICS_DEBUG_ENABLED"],
-        "version" => RSpec::Buildkite::Analytics::VERSION
+        "version" => RSpec::Buildkite::Analytics::VERSION,
+        "collector" => RSpec::Buildkite::Analytics::NAME
       }
     else
       {
         "CI" => nil,
         "key" => SecureRandom.uuid,
         "debug" => ENV["BUILDKITE_ANALYTICS_DEBUG_ENABLED"],
-        "version" => RSpec::Buildkite::Analytics::VERSION
+        "version" => RSpec::Buildkite::Analytics::VERSION,
+        "collector" => RSpec::Buildkite::Analytics::NAME
       }
     end
   end

--- a/lib/rspec/buildkite/analytics/ci.rb
+++ b/lib/rspec/buildkite/analytics/ci.rb
@@ -14,13 +14,15 @@ module RSpec::Buildkite::Analytics::CI
         "number" => ENV["BUILDKITE_BUILD_NUMBER"],
         "job_id" => ENV["BUILDKITE_JOB_ID"],
         "message" => ENV["BUILDKITE_MESSAGE"],
-        "debug" => ENV["BUILDKITE_ANALYTICS_DEBUG_ENABLED"]
+        "debug" => ENV["BUILDKITE_ANALYTICS_DEBUG_ENABLED"],
+        "version" => RSpec::Buildkite::Analytics::VERSION
       }
     else
       {
         "CI" => nil,
         "key" => SecureRandom.uuid,
-        "debug" => ENV["BUILDKITE_ANALYTICS_DEBUG_ENABLED"]
+        "debug" => ENV["BUILDKITE_ANALYTICS_DEBUG_ENABLED"],
+        "version" => RSpec::Buildkite::Analytics::VERSION
       }
     end
   end

--- a/lib/rspec/buildkite/analytics/version.rb
+++ b/lib/rspec/buildkite/analytics/version.rb
@@ -4,6 +4,7 @@ module RSpec
   module Buildkite
     module Analytics
       VERSION = "0.6.2"
+      NAME = "rspec-buildkite"
     end
   end
 end

--- a/lib/rspec/buildkite/analytics/version.rb
+++ b/lib/rspec/buildkite/analytics/version.rb
@@ -3,7 +3,7 @@
 module RSpec
   module Buildkite
     module Analytics
-      VERSION = "0.6.2"
+      VERSION = "0.6.3"
       NAME = "rspec-buildkite"
     end
   end

--- a/spec/analytics/ci_spec.rb
+++ b/spec/analytics/ci_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "RSpec::Buildkite::Analytics::CI" do
     let(:message) { "Merge pull request #1 from buildkite/branch\n commit title" }
     let(:debug) { "true" }
     let(:version) { RSpec::Buildkite::Analytics::VERSION }
+    let(:name) { RSpec::Buildkite::Analytics::NAME }
 
     before do
       allow(ENV).to receive(:[]).and_call_original
@@ -45,7 +46,8 @@ RSpec.describe "RSpec::Buildkite::Analytics::CI" do
           "job_id" => job_id,
           "message" => message,
           "debug" => debug,
-          "version" => version
+          "version" => version,
+          "collector" => name
         })
       end
     end
@@ -64,7 +66,8 @@ RSpec.describe "RSpec::Buildkite::Analytics::CI" do
           "CI" => nil,
           "key" => "845ac829-2ab3-4bbb-9e24-3529755a6d37",
           "debug" => debug,
-          "version" => version
+          "version" => version,
+          "collector" => name
         })
       end
     end

--- a/spec/analytics/ci_spec.rb
+++ b/spec/analytics/ci_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "RSpec::Buildkite::Analytics::CI" do
     let(:job_id) { "j3459ui2-l0dk-4829-i029-97999t1e09d6" }
     let(:message) { "Merge pull request #1 from buildkite/branch\n commit title" }
     let(:debug) { "true" }
+    let(:version) { RSpec::Buildkite::Analytics::VERSION }
 
     before do
       allow(ENV).to receive(:[]).and_call_original
@@ -43,7 +44,8 @@ RSpec.describe "RSpec::Buildkite::Analytics::CI" do
           "number" => number,
           "job_id" => job_id,
           "message" => message,
-          "debug" => debug
+          "debug" => debug,
+          "version" => version
         })
       end
     end
@@ -61,7 +63,8 @@ RSpec.describe "RSpec::Buildkite::Analytics::CI" do
         expect(result).to match({
           "CI" => nil,
           "key" => "845ac829-2ab3-4bbb-9e24-3529755a6d37",
-          "debug" => debug
+          "debug" => debug,
+          "version" => version
         })
       end
     end


### PR DESCRIPTION
We talked vaguely in the planning meeting about storing the collector version in the upload jsons S3 file but I thought that 
maybe it was easier/more efficient to just put it in the run env? Store it once per run rather than once upload part? It's also less code changes this way 😂 