### PR TITLE
Add support for annotation spans

### DIFF
--- a/lib/rspec/buildkite/analytics.rb
+++ b/lib/rspec/buildkite/analytics.rb
@@ -30,4 +30,10 @@ module RSpec::Buildkite::Analytics
 
     self::Uploader.configure
   end
+
+  def self.annotate(content)
+    tracer = RSpec::Buildkite::Analytics::Uploader.tracer
+    tracer&.enter("annotation", **{ content: content })
+    tracer&.leave
+  end
 end


### PR DESCRIPTION
This PR adds support for basic annotations. Annotations a special kind of span that will be supported by Test Analytics to facilitate easier debugging of threaded code within a test execution.

An annotation can be created by calling `RSpec::Buildkite::Analytics.annotate("some kind of annotation string")`

It'll then show as something like this in the UI.

![Screen Shot 2022-02-07 at 11 08 02 am](https://user-images.githubusercontent.com/1002901/152708751-8784a52a-99d5-4d7b-b3c5-6b5ce28c068a.png)
.