### PR TITLE
Support multiple CI platforms and generic env

### DIFF
--- a/lib/rspec/buildkite/analytics/ci.rb
+++ b/lib/rspec/buildkite/analytics/ci.rb
@@ -2,30 +2,85 @@
 
 require "securerandom"
 
-module RSpec::Buildkite::Analytics::CI
+class RSpec::Buildkite::Analytics::CI
   def self.env
-    if ENV["BUILDKITE_BUILD_ID"]
-      {
-        "CI" => "buildkite",
-        "key" => ENV["BUILDKITE_BUILD_ID"],
-        "url" => ENV["BUILDKITE_BUILD_URL"],
-        "branch" => ENV["BUILDKITE_BRANCH"],
-        "commit_sha" => ENV["BUILDKITE_COMMIT"],
-        "number" => ENV["BUILDKITE_BUILD_NUMBER"],
-        "job_id" => ENV["BUILDKITE_JOB_ID"],
-        "message" => ENV["BUILDKITE_MESSAGE"],
-        "debug" => ENV["BUILDKITE_ANALYTICS_DEBUG_ENABLED"],
-        "version" => RSpec::Buildkite::Analytics::VERSION,
-        "collector" => RSpec::Buildkite::Analytics::NAME
-      }
-    else
-      {
-        "CI" => nil,
-        "key" => SecureRandom.uuid,
-        "debug" => ENV["BUILDKITE_ANALYTICS_DEBUG_ENABLED"],
-        "version" => RSpec::Buildkite::Analytics::VERSION,
-        "collector" => RSpec::Buildkite::Analytics::NAME
-      }
-    end
+    new.env
+  end
+
+  # The analytics env are more specific than the automatic ci platform env.
+  # If they've been specified we'll assume the user wants to use that value instead.
+  def env
+    ci_env.merge(analytics_env)
+  end
+
+  private
+
+  def ci_env
+    return buildkite if ENV["BUILDKITE_BUILD_ID"]
+    return github_actions if ENV["GITHUB_RUN_NUMBER"]
+    return circleci if ENV["CIRCLE_BUILD_NUM"]
+    return generic if ENV["CI"]
+
+    {
+      "CI" => nil,
+      "key" => SecureRandom.uuid,
+    }
+  end
+
+  def analytics_env
+    {
+      "key" => ENV["BUILDKITE_ANALYTICS_KEY"],
+      "url" => ENV["BUILDKITE_ANALYTICS_URL"],
+      "branch" => ENV["BUILDKITE_ANALYTICS_BRANCH"],
+      "commit_sha" => ENV["BUILDKITE_ANALYTICS_SHA"],
+      "number" => ENV["BUILDKITE_ANALYTICS_NUMBER"],
+      "job_id" => ENV["BUILDKITE_ANALYTICS_JOB_ID"],
+      "message" => ENV["BUILDKITE_ANANLYTICS_MESSAGE"],
+      "debug" => ENV["BUILDKITE_ANALYTICS_DEBUG_ENABLED"],
+      "version" => RSpec::Buildkite::Analytics::VERSION,
+      "collector" => RSpec::Buildkite::Analytics::NAME,
+  }.compact
+  end
+
+  def generic
+    {
+      "CI" => "generic",
+      "key" => SecureRandom.uuid,
+    }
+  end
+
+  def buildkite
+    {
+      "CI" => "buildkite",
+      "key" => ENV["BUILDKITE_BUILD_ID"],
+      "url" => ENV["BUILDKITE_BUILD_URL"],
+      "branch" => ENV["BUILDKITE_BRANCH"],
+      "commit_sha" => ENV["BUILDKITE_COMMIT"],
+      "number" => ENV["BUILDKITE_BUILD_NUMBER"],
+      "job_id" => ENV["BUILDKITE_JOB_ID"],
+      "message" => ENV["BUILDKITE_MESSAGE"],
+    }
+  end
+
+  def github_actions
+    {
+      "CI" => "github_actions",
+      "key" => "#{ENV["GITHUB_ACTION"]}-#{ENV["GITHUB_RUN_NUMBER"]}-#{ENV["GITHUB_RUN_ATTEMPT"]}",
+      "url" => File.join("https://github.com", ENV["GITHUB_REPOSITORY"], "actions/runs", ENV["GITHUB_RUN_ID"]),
+      "branch" => ENV["GITHUB_REF"],
+      "commit_sha" => ENV["GITHUB_SHA"],
+      "number" => ENV["GITHUB_RUN_NUMBER"],
+    }
+  end
+
+  def circleci
+    {
+      "CI" => "circleci",
+      "key" => "#{ENV["CIRCLE_WORKFLOW_ID"]}-#{ENV["CIRCLE_BUILD_NUM"]}",
+      "url" => ENV["CIRCLE_BUILD_URL"],
+      "branch" => ENV["CIRCLE_BRANCH"],
+      "commit_sha" => ENV["CIRCLE_SHA1"],
+      "number" => ENV["CIRCLE_BUILD_NUM"],
+    }
   end
 end

--- a/spec/analytics/ci_spec.rb
+++ b/spec/analytics/ci_spec.rb
@@ -4,13 +4,14 @@ require "rspec/buildkite/analytics/ci"
 
 RSpec.describe "RSpec::Buildkite::Analytics::CI" do
   describe ".env" do
-    let(:build_uuid) { "b8959ui2-l0dk-4829-i029-97999t1e09d6" }
-    let(:build_url) { "https://buildkite.com/buildkite/buildkite/builds/1234" }
-    let(:branch) { "main" }
-    let(:commit_sha) { "3683a9a92ec0f3055849cd5488e8e9347c6e2878" }
-    let(:number) { "4242" }
-    let(:job_id) { "j3459ui2-l0dk-4829-i029-97999t1e09d6" }
-    let(:message) { "Merge pull request #1 from buildkite/branch\n commit title" }
+    let(:ci) { "true" }
+    let(:key) { SecureRandom.uuid }
+    let(:url) { "http://example.com" }
+    let(:branch) { "not-main" }
+    let(:sha) { "a2c5ef54" }
+    let(:number) { "424242" }
+    let(:job_id) { "242424" }
+    let(:message) { "bananas are tasty" }
     let(:debug) { "true" }
     let(:version) { RSpec::Buildkite::Analytics::VERSION }
     let(:name) { RSpec::Buildkite::Analytics::NAME }
@@ -18,19 +19,33 @@ RSpec.describe "RSpec::Buildkite::Analytics::CI" do
     before do
       allow(ENV).to receive(:[]).and_call_original
 
-      fake_env("BUILDKITE_BUILD_ID", build_uuid)
-      fake_env("BUILDKITE_BUILD_URL", build_url)
-      fake_env("BUILDKITE_BRANCH", branch)
-      fake_env("BUILDKITE_COMMIT", commit_sha)
-      fake_env("BUILDKITE_BUILD_NUMBER", number)
-      fake_env("BUILDKITE_JOB_ID", job_id)
-      fake_env("BUILDKITE_MESSAGE", message)
       fake_env("BUILDKITE_ANALYTICS_DEBUG_ENABLED", debug)
+
+      # these have to be reset or these tests will fail on these platforms
+      fake_env("CI", nil)
+      fake_env("BUILDKITE_BUILD_ID", nil)
+      fake_env("GITHUB_RUN_NUMBER", nil)
+      fake_env("CIRCLE_BUILD_NUM", nil)
     end
 
-    context "when BUILDKITE_BUILD_ID is set" do
+    context "when running on Buildkite" do
+      let(:bk_build_uuid) { "b8959ui2-l0dk-4829-i029-97999t1e09d6" }
+      let(:bk_build_url) { "https://buildkite.com/buildkite/buildkite/builds/1234" }
+      let(:bk_branch) { "main" }
+      let(:bk_sha) { "3683a9a92ec0f3055849cd5488e8e9347c6e2878" }
+      let(:bk_number) { "4242" }
+      let(:bk_job_id) { "j3459ui2-l0dk-4829-i029-97999t1e09d6" }
+      let(:bk_message) { "Merge pull request #1 from buildkite/branch\n commit title" }
+
       before do
-        fake_env("BUILDKITE_BUILD_ID", build_uuid)
+        fake_env("CI", ci)
+        fake_env("BUILDKITE_BUILD_ID", bk_build_uuid)
+        fake_env("BUILDKITE_BUILD_URL", bk_build_url)
+        fake_env("BUILDKITE_BRANCH", bk_branch)
+        fake_env("BUILDKITE_COMMIT", bk_sha)
+        fake_env("BUILDKITE_BUILD_NUMBER", bk_number)
+        fake_env("BUILDKITE_JOB_ID", bk_job_id)
+        fake_env("BUILDKITE_MESSAGE", bk_message)
       end
 
       it "returns all env" do
@@ -38,28 +53,236 @@ RSpec.describe "RSpec::Buildkite::Analytics::CI" do
 
         expect(result).to match({
           "CI" => "buildkite",
-          "key" => build_uuid,
-          "url" => build_url,
-          "branch" => branch,
-          "commit_sha" => commit_sha,
-          "number" => number,
-          "job_id" => job_id,
-          "message" => message,
+          "key" => bk_build_uuid,
+          "url" => bk_build_url,
+          "branch" => bk_branch,
+          "commit_sha" => bk_sha,
+          "number" => bk_number,
+          "job_id" => bk_job_id,
+          "message" => bk_message,
           "debug" => debug,
           "version" => version,
           "collector" => name
         })
       end
+
+      context "when setting the analytics env" do
+        before do
+          fake_env("BUILDKITE_ANALYTICS_KEY", key)
+          fake_env("BUILDKITE_ANALYTICS_URL", url)
+          fake_env("BUILDKITE_ANALYTICS_BRANCH", branch)
+          fake_env("BUILDKITE_ANALYTICS_SHA", sha)
+          fake_env("BUILDKITE_ANALYTICS_NUMBER", number)
+          fake_env("BUILDKITE_ANALYTICS_JOB_ID", job_id)
+          fake_env("BUILDKITE_ANANLYTICS_MESSAGE", message)
+        end
+
+        it "returns the analytics env" do
+          result = RSpec::Buildkite::Analytics::CI.env
+
+          expect(result).to match({
+            "CI" => "buildkite",
+            "key" => key,
+            "url" => url,
+            "branch" => branch,
+            "commit_sha" => sha,
+            "number" => number,
+            "job_id" => job_id,
+            "message" => message,
+            "debug" => debug,
+            "version" => version,
+            "collector" => name
+          })
+        end
+      end
     end
 
-    context "when BUILDKITE_BUILD_ID is not set" do
-      before do
-        allow(SecureRandom).to receive(:uuid) { "845ac829-2ab3-4bbb-9e24-3529755a6d37" }
+    context "when running on GitHub Actions" do
+      let(:gha_run_number) { "4242" }
+      let(:gha_action) { "some_action" }
+      let(:gha_run_attempt) { "1" }
+      let(:gha_run_id) { "2424" }
+      let(:gha_repository) { "rofl/lol" }
+      let(:gha_ref) { "main" }
+      let(:gha_sha) { "3683a9a92ec0f3055849cd5488e8e9347c6e2878" }
 
-        fake_env("BUILDKITE_BUILD_ID", nil)
+      before do
+        fake_env("CI", ci)
+        fake_env("GITHUB_RUN_NUMBER", gha_run_number)
+        fake_env("GITHUB_ACTION", gha_action)
+        fake_env("GITHUB_RUN_ATTEMPT", gha_run_attempt)
+        fake_env("GITHUB_RUN_ID", gha_run_id)
+        fake_env("GITHUB_REPOSITORY", gha_repository)
+        fake_env("GITHUB_REF", gha_ref)
+        fake_env("GITHUB_SHA", gha_sha)
       end
 
-      it "returns the key and debug" do
+      it "returns all env" do
+        result = RSpec::Buildkite::Analytics::CI.env
+
+        expect(result).to match({
+          "CI" => "github_actions",
+          "key" => "some_action-4242-1",
+          "url" => "https://github.com/rofl/lol/actions/runs/2424",
+          "branch" => gha_ref,
+          "commit_sha" => gha_sha,
+          "number" => gha_run_number,
+          "debug" => debug,
+          "version" => version,
+          "collector" => name
+        })
+      end
+
+      context "when setting the analytics env" do
+        before do
+          fake_env("BUILDKITE_ANALYTICS_KEY", key)
+          fake_env("BUILDKITE_ANALYTICS_URL", url)
+          fake_env("BUILDKITE_ANALYTICS_BRANCH", branch)
+          fake_env("BUILDKITE_ANALYTICS_SHA", sha)
+          fake_env("BUILDKITE_ANALYTICS_NUMBER", number)
+          fake_env("BUILDKITE_ANALYTICS_JOB_ID", job_id)
+          fake_env("BUILDKITE_ANANLYTICS_MESSAGE", message)
+        end
+
+        it "returns the analytics env" do
+          result = RSpec::Buildkite::Analytics::CI.env
+
+          expect(result).to match({
+            "CI" => "github_actions",
+            "key" => key,
+            "url" => url,
+            "branch" => branch,
+            "commit_sha" => sha,
+            "number" => number,
+            "job_id" => job_id,
+            "message" => message,
+            "debug" => debug,
+            "version" => version,
+            "collector" => name
+          })
+        end
+      end
+    end
+
+    context "when running on CircleCI" do
+      let(:c_workflow_id) { "4242" }
+      let(:c_number) { "2424" }
+      let(:c_url) { "http://example.com/circle" }
+      let(:c_branch) { "main" }
+      let(:c_sha) { "3683a9a92ec0f3055849cd5488e8e9347c6e2878" }
+
+      before do
+        fake_env("CI", ci)
+        fake_env("CIRCLE_WORKFLOW_ID", c_workflow_id)
+        fake_env("CIRCLE_BUILD_NUM", c_number)
+        fake_env("CIRCLE_BUILD_URL", c_url)
+        fake_env("CIRCLE_BRANCH", c_branch)
+        fake_env("CIRCLE_SHA1", c_sha)
+      end
+
+      it "returns all env" do
+        result = RSpec::Buildkite::Analytics::CI.env
+
+        expect(result).to match({
+          "CI" => "circleci",
+          "key" => "4242-2424",
+          "url" => c_url,
+          "branch" => c_branch,
+          "commit_sha" => c_sha,
+          "number" => c_number,
+          "debug" => debug,
+          "version" => version,
+          "collector" => name
+        })
+      end
+
+      context "when setting the analytics env" do
+        before do
+          fake_env("BUILDKITE_ANALYTICS_KEY", key)
+          fake_env("BUILDKITE_ANALYTICS_URL", url)
+          fake_env("BUILDKITE_ANALYTICS_BRANCH", branch)
+          fake_env("BUILDKITE_ANALYTICS_SHA", sha)
+          fake_env("BUILDKITE_ANALYTICS_NUMBER", number)
+          fake_env("BUILDKITE_ANALYTICS_JOB_ID", job_id)
+          fake_env("BUILDKITE_ANANLYTICS_MESSAGE", message)
+        end
+
+        it "returns the analytics env" do
+          result = RSpec::Buildkite::Analytics::CI.env
+
+          expect(result).to match({
+            "CI" => "circleci",
+            "key" => key,
+            "url" => url,
+            "branch" => branch,
+            "commit_sha" => sha,
+            "number" => number,
+            "job_id" => job_id,
+            "message" => message,
+            "debug" => debug,
+            "version" => version,
+            "collector" => name
+          })
+        end
+      end
+    end
+
+    context "when running on a generic CI platform" do
+      before do
+        fake_env("CI", ci)
+
+        allow(SecureRandom).to receive(:uuid) { "845ac829-2ab3-4bbb-9e24-3529755a6d37" }
+      end
+
+      it "returns all env" do
+        result = RSpec::Buildkite::Analytics::CI.env
+
+        expect(result).to match({
+          "CI" => "generic",
+          "key" => key,
+          "debug" => debug,
+          "version" => version,
+          "collector" => name
+        })
+      end
+
+      context "when setting the analytics env" do
+        before do
+          fake_env("BUILDKITE_ANALYTICS_KEY", key)
+          fake_env("BUILDKITE_ANALYTICS_URL", url)
+          fake_env("BUILDKITE_ANALYTICS_BRANCH", branch)
+          fake_env("BUILDKITE_ANALYTICS_SHA", sha)
+          fake_env("BUILDKITE_ANALYTICS_NUMBER", number)
+          fake_env("BUILDKITE_ANALYTICS_JOB_ID", job_id)
+          fake_env("BUILDKITE_ANANLYTICS_MESSAGE", message)
+        end
+
+        it "returns the analytics env" do
+          result = RSpec::Buildkite::Analytics::CI.env
+
+          expect(result).to match({
+            "CI" => "generic",
+            "key" => key,
+            "url" => url,
+            "branch" => branch,
+            "commit_sha" => sha,
+            "number" => number,
+            "job_id" => job_id,
+            "message" => message,
+            "debug" => debug,
+            "version" => version,
+            "collector" => name
+          })
+        end
+      end
+    end
+
+    context "when not running on a CI platform" do
+      before do
+        allow(SecureRandom).to receive(:uuid) { "845ac829-2ab3-4bbb-9e24-3529755a6d37" }
+      end
+
+      it "returns all env" do
         result = RSpec::Buildkite::Analytics::CI.env
 
         expect(result).to match({
@@ -69,6 +292,36 @@ RSpec.describe "RSpec::Buildkite::Analytics::CI" do
           "version" => version,
           "collector" => name
         })
+      end
+
+      context "when setting the analytics env" do
+        before do
+          fake_env("BUILDKITE_ANALYTICS_KEY", key)
+          fake_env("BUILDKITE_ANALYTICS_URL", url)
+          fake_env("BUILDKITE_ANALYTICS_BRANCH", branch)
+          fake_env("BUILDKITE_ANALYTICS_SHA", sha)
+          fake_env("BUILDKITE_ANALYTICS_NUMBER", number)
+          fake_env("BUILDKITE_ANALYTICS_JOB_ID", job_id)
+          fake_env("BUILDKITE_ANANLYTICS_MESSAGE", message)
+        end
+
+        it "returns the analytics env" do
+          result = RSpec::Buildkite::Analytics::CI.env
+
+          expect(result).to match({
+            "CI" => nil,
+            "key" => key,
+            "url" => url,
+            "branch" => branch,
+            "commit_sha" => sha,
+            "number" => number,
+            "job_id" => job_id,
+            "message" => message,
+            "debug" => debug,
+            "version" => version,
+            "collector" => name
+          })
+        end
       end
     end
   end


### PR DESCRIPTION
This PR reinstates the support for GitHub Actions and CircleCI. It also adds support for override environment variables in the `BUILDKITE_ANALYTICS_` namespace.

If `GITHUB_RUN_NUMBER` is set then we will apply some sensible defaults for the run env based on those provided by GitHub Actions. If `CIRCLE_BUILD_NUM` is set we do the same for CircleCI. When the generic `CI` environment variable is set the run env "ci" is set to "generic".

When a URL and NUMBER are provided a link to the build will show in the Test Analytics UI regardless of CI platform. This also applies when the `CI` env is not set but `BUILDKITE_ANALYTICS_URL` and `BUILDKITE_ANALYTICS_NUMBER` are set.

![Screen Shot 2022-02-16 at 8 25 57 pm](https://user-images.githubusercontent.com/1002901/154240110-25c77fae-26c9-4c96-9d04-e992706c972a.png)

`BUILDKITE_ANANLYTICS_MESSAGE` can be used within CI platforms that do not have an environment variable that is equivalent to `BUILDKITE_MESSAGE`.

Supported variables:
`BUILDKITE_ANALYTICS_KEY` - a unique key for the build that initiated the Test Analytics run.
`BUILDKITE_ANALYTICS_URL` - a URL that links to the build.
`BUILDKITE_ANALYTICS_BRANCH` - the branch or ref that this run is for.
`BUILDKITE_ANALYTICS_SHA` - the commit sha for the head of the branch.
`BUILDKITE_ANALYTICS_NUMBER` - the build number of the build.
`BUILDKITE_ANALYTICS_JOB_ID` - the id of a job within the build.
`BUILDKITE_ANANLYTICS_MESSAGE` - the commit message for the head of the branch.