### PR TITLE
Replace invalid UTF-8 characters in test names

### DIFF
--- a/lib/rspec/buildkite/analytics/uploader.rb
+++ b/lib/rspec/buildkite/analytics/uploader.rb
@@ -42,7 +42,7 @@ module RSpec::Buildkite::Analytics
       end
 
       def as_hash
-        {
+        strip_invalid_utf8_chars(
           id: @id,
           scope: example.example_group.metadata[:full_description],
           name: example.description,
@@ -53,14 +53,14 @@ module RSpec::Buildkite::Analytics
           failure_reason: failure_reason,
           failure_expanded: failure_expanded,
           history: history,
-        }.with_indifferent_access.compact
+        )
       end
 
       private
 
       def generate_file_name(example)
         file_path_regex = /^(.*?\.(rb|feature))/
-        identifier_file_name = example.id[file_path_regex]
+        identifier_file_name = strip_invalid_utf8_chars(example.id)[file_path_regex]
         location_file_name = example.location[file_path_regex]
 
         if identifier_file_name != location_file_name
@@ -76,6 +76,16 @@ module RSpec::Buildkite::Analytics
           end
         else
           identifier_file_name
+        end
+      end
+
+      def strip_invalid_utf8_chars(object)
+        if(object.is_a?(Hash))
+          Hash[object.map { |key, value| [key, strip_invalid_utf8_chars(value)] }]
+        elsif object.is_a?(Array)
+          object.map { |value| strip_invalid_utf8_chars(value) }
+        elsif object.is_a?(String)
+          object.encode('UTF-8', :invalid => :replace, :undef => :replace)
         end
       end
     end

--- a/lib/rspec/buildkite/analytics/uploader.rb
+++ b/lib/rspec/buildkite/analytics/uploader.rb
@@ -53,7 +53,7 @@ module RSpec::Buildkite::Analytics
           failure_reason: failure_reason,
           failure_expanded: failure_expanded,
           history: history,
-        )
+        ).with_indifferent_access.compact
       end
 
       private
@@ -80,12 +80,14 @@ module RSpec::Buildkite::Analytics
       end
 
       def strip_invalid_utf8_chars(object)
-        if(object.is_a?(Hash))
+        if object.is_a?(Hash)
           Hash[object.map { |key, value| [key, strip_invalid_utf8_chars(value)] }]
         elsif object.is_a?(Array)
           object.map { |value| strip_invalid_utf8_chars(value) }
         elsif object.is_a?(String)
           object.encode('UTF-8', :invalid => :replace, :undef => :replace)
+        else
+          object
         end
       end
     end

--- a/spec/analytics/uploader_spec.rb
+++ b/spec/analytics/uploader_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rspec/buildkite/analytics/uploader"
+
+RSpec.describe "RSpec::Buildkite::Analytics::Uploader::Trace" do
+  subject(:trace) { RSpec::Buildkite::Analytics::Uploader::Trace.new(example, history) }
+  let(:example) { double(id: "test for invalid character '\xC8'").as_null_object }
+  let(:history) do
+    {
+      children: [
+        {
+          detail: %{"query"=>"SELECT '\xC8'"}
+        }
+      ]
+    }
+  end
+
+  describe '#as_hash' do
+    it 'removes invalid UTF-8 characters from top level values' do
+      identifier = trace.as_hash[:identifier]
+
+      expect(identifier).to include('test for invalid character')
+      expect(identifier).to be_valid_encoding
+    end
+
+    it 'removes invalid UTF-8 characters from nested values' do
+      history_json = trace.as_hash[:history].to_json
+
+      expect(history_json).to include('query')
+      expect(history_json).to be_valid_encoding
+    end
+  end
+end

--- a/spec/analytics/uploader_spec.rb
+++ b/spec/analytics/uploader_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "RSpec::Buildkite::Analytics::Uploader::Trace" do
     {
       children: [
         {
+          start_at: 347611.734956,
           detail: %{"query"=>"SELECT '\xC8'"}
         }
       ]
@@ -28,6 +29,12 @@ RSpec.describe "RSpec::Buildkite::Analytics::Uploader::Trace" do
 
       expect(history_json).to include('query')
       expect(history_json).to be_valid_encoding
+    end
+
+    it 'does not alter data types which are not strings' do
+      history_json = trace.as_hash[:history].to_json
+
+      expect(history_json).to include('347611.734956')
     end
   end
 end


### PR DESCRIPTION
In the `Session` class we convert our test results into a JSON string to
send over the wire. Calling `to_json` on a string that has invalid UTF-8
characters result in a `JSON::GeneratorError`. Which means that if a
test name, or any other data we generate has any invalid characters we
won't be able to send the results to analytics. So we replace any of
these characters.

I think it would have been good to avoid the recursive function here and
only re-encoded the strings that are generated from the users test
suite, but that happens in quite a few places, it would be easy to skip
doing this when adding additional data from the test suite as well; also
those values appearing in deep nested structures, so we can't just call
that function for a few keys, we need to recursively visit each string
in our hash.