### PR TITLE
Relax Active Support constraint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rspec-buildkite-analytics (0.7.0)
-      activesupport (>= 5.2, <= 7.0)
+      activesupport (>= 5.2, < 8)
       rspec-core (~> 3.10)
       rspec-expectations (~> 3.10)
       websocket (~> 1.2)

--- a/rspec-buildkite-analytics.gemspec
+++ b/rspec-buildkite-analytics.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
 
-  spec.add_dependency "activesupport", ">= 5.2", "<= 7.0"
+  spec.add_dependency "activesupport", ">= 5.2", "< 8"
   spec.add_dependency "rspec-core", '~> 3.10'
   spec.add_dependency "rspec-expectations", '~> 3.10'
   spec.add_dependency "websocket", '~> 1.2'


### PR DESCRIPTION
The current constraint on ActiveSupport prevents using this gem with patch releases of ActiveSupport / Rails 7, e.g.

```
Bundler could not find compatible versions for gem "activesupport":
  In Gemfile:
    rails (= 7.0.2.3) was resolved to 7.0.2.3, which depends on
      activesupport (= 7.0.2.3)

    rspec-buildkite-analytics was resolved to 0.6.1, which depends on
      activesupport (>= 5.2, <= 7.0)
```

This relaxes the constraint to permit them.