### PR TITLE
Add security advice to API key config in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,14 @@ group :test do
 end
 ```
 
+Set the `BUILDKITE_ANALYTICS_KEY` environment variable, either via the command line or using a secure method like Rails custom credentials (https://edgeguides.rubyonrails.org/security.html#custom-credentials).
+
+Please avoid committing your API key to your repository for security reasons.
+
+
 Configure your API key:
 ```ruby
-RSpec::Buildkite::Analytics.configure(token: "........")
+RSpec::Buildkite::Analytics.configure(token: ENV["BUILDKITE_ANALYTICS_KEY"])
 ```
 
 Run bundler to install the gem and update your `Gemfile.lock`:


### PR DESCRIPTION
The original instructions seem to imply that you should add your API key directly to a config line in your repo. Which is generally considered unwise. Probably best to guide users well away from this option if at all possible.

This is just a draft proposal so please change/expand/discuss!

/cc @toolmantim @keithpitt 