### PR TITLE
Update README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,32 +4,46 @@ This gem collects data about your test suite's performance and reliability, and 
 
 ## Installation
 
-Add the gem to your Gemfile:
+1. Create a new branch
+
+```sh
+git checkout -b install-buildkite-test-analytics
+```
+
+2. Add the `rspec-buildkite-analytics` gem to your `Gemfile` in the `test` group
 
 ```ruby
 group :test do
-  # ...
   gem "rspec-buildkite-analytics"
 end
 ```
 
-Configure your API key:
-```ruby
-RSpec::Buildkite::Analytics.configure(token: "........")
-```
+3. Run `bundle` to install the gem and update your `Gemfile.lock`
 
-Run bundler to install the gem and update your `Gemfile.lock`:
-```
+```sh
 $ bundle
 ```
 
-Lastly, commit and push your changes to start analysing your tests:
+4. Add the Test Analytics code to your application in `spec/spec_helper.rb`, and [set the environment variable securely](https://buildkite.com/docs/pipelines/secrets) on your agent or agents.
+
+```ruby
+require "rspec/buildkite/analytics"
+
+RSpec::Buildkite::Analytics.configure(ENV["TEST_ANALYTICS_TOKEN"])
 ```
+
+5. Commit and push your changes to start analysing your tests
+
+```sh
+$ git add .
 $ git commit -m "Add Buildkite Test Analytics client"
 $ git push
 ```
 
+6. Make sure that the [Test Analytics environment variables](https://buildkite.com/docs/test-analytics/integrations#integrating-with-rspec-environment-variables) are set so that the RSpec integration can use them in your Test Analytics dashboard.
+
 ## Contributing
+
 Bug reports and pull requests are welcome on GitHub at https://github.com/buildkite/rspec-buildkite-analytics.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ bundle
 ```ruby
 require "rspec/buildkite/analytics"
 
-RSpec::Buildkite::Analytics.configure(ENV["TEST_ANALYTICS_TOKEN"])
+RSpec::Buildkite::Analytics.configure(ENV["BUILDKITE_ANALYTICS_TOKEN"])
 ```
 
 5. Commit and push your changes to start analysing your tests


### PR DESCRIPTION
Updated installation instruction to match https://buildkite.com/docs/test-analytics/integrations#integrating-with-rspec

This also fixes the security raised in #89 and replaces that PR.