### PR TITLE
Bump version to v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# CHANGELOG
+
+## v0.8.0
+
+- Support multiple CI platforms and generic env #80 — @blaknite
+- Replace invalid UTF-8 characters in test names #85 — @mariovisic
+- Relax Active Support constraint #87 — @ags

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rspec-buildkite-analytics (0.7.0)
+    rspec-buildkite-analytics (0.8.0)
       activesupport (>= 5.2, < 8)
       rspec-core (~> 3.10)
       rspec-expectations (~> 3.10)
@@ -10,14 +10,14 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.0)
+    activesupport (7.0.2.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     diff-lcs (1.4.4)
-    i18n (1.9.1)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     minitest (5.15.0)
     rake (13.0.6)

--- a/lib/rspec/buildkite/analytics/version.rb
+++ b/lib/rspec/buildkite/analytics/version.rb
@@ -3,7 +3,7 @@
 module RSpec
   module Buildkite
     module Analytics
-      VERSION = "0.7.0"
+      VERSION = "0.8.0"
       NAME = "rspec-buildkite"
     end
   end


### PR DESCRIPTION
Bump version to v0.8.0: [CHANGES](https://github.com/buildkite/rspec-buildkite-analytics/compare/v0.7.0...main).