### PR TITLE
Introduce Logger utility

### DIFF
--- a/lib/buildkite/collector.rb
+++ b/lib/buildkite/collector.rb
@@ -4,6 +4,7 @@ require "timeout"
 require "tmpdir"
 
 require_relative "collector/version"
+require_relative "collector/logger"
 
 module Buildkite
   module Collector

--- a/lib/buildkite/collector.rb
+++ b/lib/buildkite/collector.rb
@@ -43,5 +43,29 @@ module Buildkite
       tracer&.enter("annotation", **{ content: content })
       tracer&.leave
     end
+
+    def self.log_formatter
+      @log_formatter ||= Buildkite::Collector::Logger::Formatter.new
+    end
+
+    def self.log_formatter=(log_formatter)
+      @log_formatter = log_formatter
+      logger.formatter = log_formatter
+    end
+
+    def self.logger=(logger)
+      @logger = logger
+    end
+
+    def self.logger
+      return @logger if defined?(@logger)
+
+      debug_mode = ENV.fetch("BUILDKITE_ANALYTICS_DEBUG_ENABLED") do
+        $DEBUG
+      end
+
+      level = !!debug_mode ? ::Logger::DEBUG : ::Logger::WARN
+      @logger ||= Buildkite::Collector::Logger.new($stderr, level)
+    end
   end
 end

--- a/lib/buildkite/collector/logger.rb
+++ b/lib/buildkite/collector/logger.rb
@@ -1,0 +1,41 @@
+require "logger"
+require "time"
+
+module Buildkite::Collector
+  class CustomFormatter < ::Logger::Formatter
+    def call(severity, time, _program, message)
+      "#{time.utc.iso8601(9)} pid=#{::Process.pid} tid=#{::Thread.current.object_id} #{severity}: #{message}\n"
+    end
+  end
+
+  class CustomLogger < ::Logger
+    def initialize(*args, **kwargs)
+      super
+      self.formatter = Buildkite::Collector.log_formatter
+    end
+  end
+
+  def self.log_formatter
+    @log_formatter ||= CustomFormatter.new
+  end
+
+  def self.log_formatter=(log_formatter)
+    @log_formatter = log_formatter
+    logger.formatter = log_formatter
+  end
+
+  def self.logger=(logger)
+    @logger = logger
+  end
+
+  def self.logger
+    return @logger if defined?(@logger)
+
+    debug_mode = ENV.fetch("BUILDKITE_ANALYTICS_DEBUG_ENABLED") do
+      $DEBUG
+    end
+
+    level = !!debug_mode ? ::Logger::DEBUG : ::Logger::WARN
+    @logger ||= CustomLogger.new($stderr, level)
+  end
+end

--- a/lib/buildkite/collector/logger.rb
+++ b/lib/buildkite/collector/logger.rb
@@ -2,40 +2,16 @@ require "logger"
 require "time"
 
 module Buildkite::Collector
-  class CustomFormatter < ::Logger::Formatter
-    def call(severity, time, _program, message)
-      "#{time.utc.iso8601(9)} pid=#{::Process.pid} tid=#{::Thread.current.object_id} #{severity}: #{message}\n"
+  class Logger < ::Logger
+    class Formatter < ::Logger::Formatter
+      def call(severity, time, _program, message)
+        "#{time.utc.iso8601(9)} pid=#{::Process.pid} tid=#{::Thread.current.object_id} #{severity}: #{message}\n"
+      end
     end
-  end
 
-  class CustomLogger < ::Logger
     def initialize(*args, **kwargs)
       super
       self.formatter = Buildkite::Collector.log_formatter
     end
-  end
-
-  def self.log_formatter
-    @log_formatter ||= CustomFormatter.new
-  end
-
-  def self.log_formatter=(log_formatter)
-    @log_formatter = log_formatter
-    logger.formatter = log_formatter
-  end
-
-  def self.logger=(logger)
-    @logger = logger
-  end
-
-  def self.logger
-    return @logger if defined?(@logger)
-
-    debug_mode = ENV.fetch("BUILDKITE_ANALYTICS_DEBUG_ENABLED") do
-      $DEBUG
-    end
-
-    level = !!debug_mode ? ::Logger::DEBUG : ::Logger::WARN
-    @logger ||= CustomLogger.new($stderr, level)
   end
 end

--- a/lib/buildkite/collector/rspec_plugin/reporter.rb
+++ b/lib/buildkite/collector/rspec_plugin/reporter.rb
@@ -33,17 +33,6 @@ module Buildkite::Collector::RSpecPlugin
         }
 
         Buildkite::Collector.session.close(examples_count)
-
-        # Write the debug file, if debug mode is enabled
-        if Buildkite::Collector.debug_enabled
-          filename = "#{Buildkite::Collector.debug_filepath}/bk-analytics-#{Time.now.strftime("%F-%R:%S")}-#{ENV["BUILDKITE_JOB_ID"]}.log.gz"
-
-          File.open(filename, "wb") do |f|
-            gz = Zlib::GzipWriter.new(f)
-            gz.puts(Buildkite::Collector.session.logger.to_array)
-            gz.close
-          end
-        end
       end
     end
 

--- a/lib/buildkite/collector/uploader.rb
+++ b/lib/buildkite/collector/uploader.rb
@@ -36,6 +36,8 @@ module Buildkite::Collector
     ]
 
     def self.configure
+      Buildkite::Collector.logger.debug("hello from RSpec thread")
+
       if Buildkite::Collector.api_token
         contact_uri = URI.parse(Buildkite::Collector.url)
 

--- a/lib/buildkite/collector/uploader.rb
+++ b/lib/buildkite/collector/uploader.rb
@@ -56,14 +56,14 @@ module Buildkite::Collector
         response = begin
           http.request(contact)
         rescue *Buildkite::Collector::REQUEST_EXCEPTIONS => e
-          puts "Buildkite Test Analytics: Error communicating with the server: #{e.message}"
+          Buildkite::Collector.logger.error "Buildkite Test Analytics: Error communicating with the server: #{e.message}"
         end
 
         return unless response
 
         case response.code
         when "401"
-          puts "Buildkite Test Analytics: Invalid Suite API key. Please double check your Suite API key."
+          Buildkite::Collector.logger.info "Buildkite Test Analytics: Invalid Suite API key. Please double check your Suite API key."
         when "200"
           json = JSON.parse(response.body)
 
@@ -72,11 +72,11 @@ module Buildkite::Collector
           end
         else
           request_id = response.to_hash["x-request-id"]
-          puts "rspec-buildkite-analytics could not establish an initial connection with Buildkite. You may be missing some data for this test suite, please contact support."
+          Buildkite::Collector.logger.info "rspec-buildkite-analytics could not establish an initial connection with Buildkite. You may be missing some data for this test suite, please contact support."
         end
       else
         if !!ENV["BUILDKITE_BUILD_ID"]
-          puts "Buildkite Test Analytics: No Suite API key provided. You can get the API key from your Suite settings page."
+          Buildkite::Collector.logger.info "Buildkite Test Analytics: No Suite API key provided. You can get the API key from your Suite settings page."
         end
       end
     end

--- a/spec/collector/logger_spec.rb
+++ b/spec/collector/logger_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Logger" do
     let(:logger) { Buildkite::Collector }
 
     it "accepts standard logger arguments" do
-      logger = Buildkite::Collector::CustomLogger.new("/dev/null", level: Logger::INFO)
+      logger = Buildkite::Collector::Logger.new("/dev/null", level: Logger::INFO)
 
       expect(logger.level).to eq ::Logger::INFO
     end
@@ -35,16 +35,16 @@ RSpec.describe "Logger" do
       $DEBUG = debug
     end
 
-    it "returns custom logger by default" do
+    it "returns our logger by default" do
       result = Buildkite::Collector.logger
 
-      expect(result).to be_a(Buildkite::Collector::CustomLogger)
+      expect(result).to be_a(Buildkite::Collector::Logger)
     end
 
-    it "returns custom formatter by default" do
+    it "returns our formatter by default" do
       result = Buildkite::Collector.log_formatter
 
-      expect(result).to be_a(Buildkite::Collector::CustomFormatter)
+      expect(result).to be_a(Buildkite::Collector::Logger::Formatter)
     end
 
     it "can change logger" do
@@ -73,8 +73,8 @@ RSpec.describe "Logger" do
     it "formatted output contains ISO 8601 timstamp, process and thread id" do
       # Replace IO for testing
       io = StringIO.new
-      logger = Buildkite::Collector::CustomLogger.new(io)
-      logger.formatter = Buildkite::Collector::CustomFormatter.new
+      logger = Buildkite::Collector::Logger.new(io)
+      logger.formatter = Buildkite::Collector::Logger::Formatter.new
       Buildkite::Collector.logger = logger
 
       Buildkite::Collector.logger.info "TestAnalytics-123"

--- a/spec/collector/logger_spec.rb
+++ b/spec/collector/logger_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "logger"
+require "buildkite/collector/logger"
+
+RSpec.describe "Logger" do
+  describe ".logger" do
+    let(:logger) { Buildkite::Collector }
+
+    it "accepts standard logger arguments" do
+      logger = Buildkite::Collector::CustomLogger.new("/dev/null", level: Logger::INFO)
+
+      expect(logger.level).to eq ::Logger::INFO
+    end
+
+    it "level respects BUILDKITE_ANALYTICS_DEBUG_ENABLED" do
+      env = ENV["BUILDKITE_ANALYTICS_DEBUG_ENABLED"]
+      ENV["BUILDKITE_ANALYTICS_DEBUG_ENABLED"] = "true"
+
+      result = Buildkite::Collector.logger.level
+
+      expect(result).to eq ::Logger::DEBUG
+
+      ENV["BUILDKITE_ANALYTICS_DEBUG_ENABLED"] = env
+    end
+
+    it "level respects $DEBUG" do
+      debug = $DEBUG
+      $DEBUG = true
+
+      result = Buildkite::Collector.logger.level
+
+      expect(result).to eq ::Logger::DEBUG
+
+      $DEBUG = debug
+    end
+
+    it "returns custom logger by default" do
+      result = Buildkite::Collector.logger
+
+      expect(result).to be_a(Buildkite::Collector::CustomLogger)
+    end
+
+    it "returns custom formatter by default" do
+      result = Buildkite::Collector.log_formatter
+
+      expect(result).to be_a(Buildkite::Collector::CustomFormatter)
+    end
+
+    it "can change logger" do
+      logger = ::Logger.new("/dev/null")
+      Buildkite::Collector.logger = logger
+
+      result = Buildkite::Collector.logger
+
+      expect(result).to eq logger
+    end
+
+    it "can change formatter" do
+      formatter = Logger::Formatter.new
+      Buildkite::Collector.log_formatter = formatter
+
+      result = Buildkite::Collector.log_formatter
+
+      expect(result).to eq formatter
+    end
+
+    def reset_io(io)
+      io.truncate(0)
+      io.rewind
+    end
+
+    it "formatted output contains ISO 8601 timstamp, process and thread id" do
+      # Replace IO for testing
+      io = StringIO.new
+      logger = Buildkite::Collector::CustomLogger.new(io)
+      logger.formatter = Buildkite::Collector::CustomFormatter.new
+      Buildkite::Collector.logger = logger
+
+      Buildkite::Collector.logger.info "TestAnalytics-123"
+
+      result = io.string
+
+      expect(result).to match /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6,}Z/
+      expect(result).to match /pid=\d{1,}/
+      expect(result).to match /tid=\d{1,}/
+      expect(result).to match /TestAnalytics-123/
+
+      reset_io(io)
+    end
+  end
+end

--- a/spec/collector/socket_connection_spec.rb
+++ b/spec/collector/socket_connection_spec.rb
@@ -29,8 +29,6 @@ RSpec.describe Buildkite::Collector::SocketConnection do
 
     allow(WebSocket::Frame::Outgoing::Client).to receive(:new).and_return(frame_double)
     allow(frame_double).to receive(:to_s).and_return("hi")
-
-    allow(session_double).to receive_message_chain("logger.write").with(anything).and_return(nil)
   end
 
   describe "#transmit" do


### PR DESCRIPTION
## Summary

This Pull Request adds a `Logger` class to replace `puts`, `$stderr.puts` and custom `logger.write` usages, which replace #96 that if we want to suppress unwanted log messages, set the logger to send logs to `/dev/null`:

```ruby
RSpec::Buildkite::Analytics.logger = Logger.new("/dev/null")
```


#### Detailed changes

- Introduce a Logger class which can be changed by user
- The logs can be enabled on by env `BUILDKITE_ANALYTICS_DEBUG_ENABLED` or standard Ruby flag `$DEBUG`
- default log level is `::Logger::WARN`
- The log has ISO 8601 timestamp with 9 digit precision, Process id and current Thread id
  `2022-05-19T07:43:52.795221000Z pid=1977 tid=7840 DEBUG: starting socket connection process`
- Replace all `puts`, `$stderr.puts` with `RSpec::Buildkite::Analytics.logger.debug` — Should this be `INFO` instead 🤔? To keep it simple, I replace with `.debug`.
- Replace all `logger.write` with `RSpec::Buildkite::Analytics.logger.debug`
- Do we still want to keep the `Reporter` class dump logs in a session to a file feature? If so, we will keep [this class](https://github.com/buildkite/rspec-buildkite-analytics/blob/69f7bd56cc07133387bc0b9fc4cb8b3b3cce020a/lib/rspec/buildkite/analytics/session.rb#L15-L33), but only for dumping session logs into a file. 


- [x] I’ve verified this Pull Request works with production

  <details>
  <summary>View logs</summary>

  ```
  Randomized with seed 44769
  2022-05-19T07:43:52.795221000Z pid=1977 tid=7840 DEBUG: starting socket connection process
  2022-05-19T07:43:53.541832000Z pid=1977 tid=22100 DEBUG: listening in on socket
  2022-05-19T07:43:53.561479000Z pid=1977 tid=22100 DEBUG: received welcome
  2022-05-19T07:43:53.758843000Z pid=1977 tid=22100 DEBUG: received confirm_subscription
  2022-05-19T07:43:53.760751000Z pid=1977 tid=7840 DEBUG: Connected to Buildkite Test Analytics!
  2022-05-19T07:43:53.760814000Z pid=1977 tid=7840 DEBUG: connected
  2022-05-19T07:43:53.764155000Z pid=1977 tid=22120 DEBUG: hello from write thread
  .2022-05-19T07:43:53.838176000Z pid=1977 tid=7840 DEBUG: added uuid-1 to send queue
  2022-05-19T07:43:53.839428000Z pid=1977 tid=22120 DEBUG: transmitted record_results ["uuid-1"]
  .2022-05-19T07:43:53.843890000Z pid=1977 tid=7840 DEBUG: added uuid-2 to send queue
  2022-05-19T07:43:53.844533000Z pid=1977 tid=22120 DEBUG: transmitted record_results ["uuid-2"]
  .2022-05-19T07:43:53.849759000Z pid=1977 tid=7840 DEBUG: added uuid-3 to send queue

  2022-05-19T07:43:53.850579000Z pid=1977 tid=22120 DEBUG: transmitted record_results ["uuid-3"]

  Finished in 1.87 seconds (files took 1.26 seconds to load)
  3 examples, 0 failures
  2022-05-19T07:43:53.851153000Z pid=1977 tid=7840 DEBUG: closing socket connection
  2022-05-19T07:43:53.851185000Z pid=1977 tid=7840 DEBUG: added EOT to send queue
  2022-05-19T07:43:53.851192000Z pid=1977 tid=7840 DEBUG: Waiting for Buildkite Test Analytics to send results...
  2022-05-19T07:43:53.851301000Z pid=1977 tid=7840 DEBUG: waiting for last confirm
  2022-05-19T07:43:53.851289000Z pid=1977 tid=22120 DEBUG: transmitted end_of_transmission
  2022-05-19T07:43:54.329537000Z pid=1977 tid=22100 DEBUG: received confirm for indentifiers: ["uuid-1", "uuid-2", "uuid-3"]
  2022-05-19T07:43:54.329767000Z pid=1977 tid=22100 DEBUG: all identifiers have been confirmed
  2022-05-19T07:43:54.329920000Z pid=1977 tid=7840 DEBUG: socket close
  2022-05-19T07:43:54.333010000Z pid=1977 tid=7840 DEBUG: socket disconnect
  2022-05-19T07:43:54.682756000Z pid=1977 tid=22100 DEBUG: end of file reached
  2022-05-19T07:43:54.683095000Z pid=1977 tid=7840 DEBUG: Buildkite Test Analytics completed
  2022-05-19T07:43:54.683179000Z pid=1977 tid=7840 DEBUG: socket connection closed

  Randomized with seed 44769
  ```

  </details>

##### [Ruby Logger](https://rubyapi.org/3.1/o/logger) level reference

<img width="566" alt="CleanShot 2022-05-19 at 16 57 13@2x" src="https://user-images.githubusercontent.com/1000669/169242858-97fe3230-b26f-4022-aeff-64c5b434bf8d.png">

