### PR TITLE
Make trace lookup faster by using a hash

### DIFF
--- a/lib/rspec/buildkite/analytics/library_hooks/rspec.rb
+++ b/lib/rspec/buildkite/analytics/library_hooks/rspec.rb
@@ -24,7 +24,7 @@ RSpec.configure do |config|
     tracer.finalize
 
     trace = RSpec::Buildkite::Analytics::Uploader::Trace.new(example, tracer.history)
-    RSpec::Buildkite::Analytics.uploader.traces << trace
+    RSpec::Buildkite::Analytics.uploader.traces[example.id] = trace
   end
 end
 

--- a/lib/rspec/buildkite/analytics/reporter.rb
+++ b/lib/rspec/buildkite/analytics/reporter.rb
@@ -12,9 +12,7 @@ module RSpec::Buildkite::Analytics
 
     def handle_example(notification)
       example = notification.example
-      trace = RSpec::Buildkite::Analytics.uploader.traces.find do |trace|
-        example.id == trace.example.id
-      end
+      trace = RSpec::Buildkite::Analytics.uploader.traces[example.id]
 
       if trace
         trace.example = example

--- a/lib/rspec/buildkite/analytics/uploader.rb
+++ b/lib/rspec/buildkite/analytics/uploader.rb
@@ -93,7 +93,7 @@ module RSpec::Buildkite::Analytics
     end
 
     def self.traces
-      @traces ||= []
+      @traces ||= {}
     end
 
     REQUEST_EXCEPTIONS = [


### PR DESCRIPTION
Backport from #86.

`RSpec::Buildkite::Analytics.uploader.traces` was an array and we would loop through this many times to find our matching trace. On larger test suites with 1000s of tests, it would cause 100s of 1000s of loops. We can instead lookup the value directly with a hash.