### PR TITLE
Fix namespace of Reporter

### DIFF
--- a/lib/buildkite/collector/rspec_plugin/reporter.rb
+++ b/lib/buildkite/collector/rspec_plugin/reporter.rb
@@ -50,7 +50,7 @@ module Buildkite::Collector::RSpecPlugin
     def failure_info(notification)
       failure_expanded = []
 
-      if Buildkite::Collector::Reporter::MULTIPLE_ERRORS.include?(notification.exception.class)
+      if Buildkite::Collector::RSpecPlugin::Reporter::MULTIPLE_ERRORS.include?(notification.exception.class)
         failure_reason = notification.exception.summary
         notification.exception.all_exceptions.each do |exception|
           # an example with multiple failures doesn't give us a

--- a/spec/collector/logger_spec.rb
+++ b/spec/collector/logger_spec.rb
@@ -65,11 +65,6 @@ RSpec.describe "Logger" do
       expect(result).to eq formatter
     end
 
-    def reset_io(io)
-      io.truncate(0)
-      io.rewind
-    end
-
     it "formatted output contains ISO 8601 timstamp, process and thread id" do
       # Replace IO for testing
       io = StringIO.new

--- a/spec/collector/rspec_plugin/reporter_spec.rb
+++ b/spec/collector/rspec_plugin/reporter_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "buildkite/collector/rspec_plugin/reporter"
+require "buildkite/collector/uploader"
+
+RSpec.describe Buildkite::Collector::RSpecPlugin::Reporter do
+  class FakeExecutionResult
+    attr :started_at, :finished_at, :run_time, :status, :exception
+    def initialize(status: :passed, skipped: false, pending_fixed: false, exception: nil)
+      now = Time.now
+      @started_at = now
+      @finished_at = now + rand(5)
+      @run_time = finished_at - started_at
+      @status = status
+      @skipped = skipped
+      @pending_fixed = pending_fixed
+      @exception = status == :failed ? StandardError.new("fake error") : nil
+    end
+    def example_skipped?
+      @skipped
+    end
+    def pending_fixed?
+      @pending_fixed
+    end
+  end
+
+  it "test reporter works with a failed RSpec example" do
+    Buildkite::Collector.configure(
+      token: "fake",
+      url: "http://fake.buildkite.localhost/v1/uploads",
+    )
+    io = StringIO.new
+    reporter = Buildkite::Collector::RSpecPlugin::Reporter.new(io)
+    example = double("RSpec::Core::Example")
+    allow(example).to receive(:execution_result) { FakeExecutionResult.new(status: :failed) }
+    allow(example).to receive(:id) { "spec/fake/fake_spec[1:2:3]" }
+    allow(example).to receive(:full_description) { "this is a fake error full description" }
+    allow(example).to receive(:metadata) { Hash.new(shared_group_inclusion_backtrace: []) }
+    fake_trace = double("Buildkite::Collector::RSpecPlugin::Trace", example: example)
+    allow(fake_trace).to receive(:[]) { fake_trace }
+    allow(fake_trace).to receive(:example=)
+    allow(fake_trace).to receive(:failure_reason=)
+    allow(fake_trace).to receive(:failure_expanded=)
+    allow(Buildkite::Collector.uploader).to receive(:traces) { fake_trace }
+
+    notification = RSpec::Core::Notifications::ExampleNotification.for(example)
+    allow(notification).to receive(:colorized_message_lines) { [""] }
+
+    reporter.handle_example(notification)
+
+    reset_io(io)
+  end
+end

--- a/spec/collector/rspec_plugin/reporter_spec.rb
+++ b/spec/collector/rspec_plugin/reporter_spec.rb
@@ -4,43 +4,6 @@ require "buildkite/collector/rspec_plugin/reporter"
 require "buildkite/collector/uploader"
 
 RSpec.describe Buildkite::Collector::RSpecPlugin::Reporter do
-  class FakeExecutionResult
-    attr :started_at, :finished_at, :run_time, :status, :exception
-    def initialize(status: :passed, skipped: false, pending_fixed: false, exception: nil)
-      now = Time.now
-      @started_at = now
-      @finished_at = now + rand(5)
-      @run_time = finished_at - started_at
-      @status = status
-      @skipped = skipped
-      @pending_fixed = pending_fixed
-      @exception = status == :failed ? StandardError.new("fake error") : nil
-    end
-    def example_skipped?
-      @skipped
-    end
-    def pending_fixed?
-      @pending_fixed
-    end
-  end
-
-  def fake_example(status:)
-    example = double("RSpec::Core::Example")
-    allow(example).to receive(:execution_result) { FakeExecutionResult.new(status: :failed) }
-    allow(example).to receive(:id) { "spec/fake/fake_spec[1:2:3]" }
-    allow(example).to receive(:full_description) { "this is a fake error full description" }
-    allow(example).to receive(:metadata) { Hash.new(shared_group_inclusion_backtrace: []) }
-    example
-  end
-
-  def fake_trace(a_example)
-    fake_trace = double("Buildkite::Collector::RSpecPlugin::Trace", example: a_example)
-    allow(fake_trace).to receive(:[]) { fake_trace }
-    allow(fake_trace).to receive(:example=)
-    allow(fake_trace).to receive(:failure_reason=)
-    allow(fake_trace).to receive(:failure_expanded=)
-    fake_trace
-  end
 
   it "test reporter works with a passed RSpec example" do
     Buildkite::Collector.configure(

--- a/spec/support/io_helpers.rb
+++ b/spec/support/io_helpers.rb
@@ -1,0 +1,10 @@
+module IoHelpers
+  def reset_io(io)
+    io.truncate(0)
+    io.rewind
+  end
+end
+
+RSpec.configure do |config|
+  config.include IoHelpers
+end

--- a/spec/support/rspec_example_trace_helpers.rb
+++ b/spec/support/rspec_example_trace_helpers.rb
@@ -1,0 +1,43 @@
+class FakeExecutionResult
+  attr :started_at, :finished_at, :run_time, :status, :exception
+  def initialize(status: :passed, skipped: false, pending_fixed: false, exception: nil)
+    now = Time.now
+    @started_at = now
+    @finished_at = now + rand(5)
+    @run_time = finished_at - started_at
+    @status = status
+    @skipped = skipped
+    @pending_fixed = pending_fixed
+    @exception = status == :failed ? StandardError.new("fake error") : nil
+  end
+  def example_skipped?
+    @skipped
+  end
+  def pending_fixed?
+    @pending_fixed
+  end
+end
+
+module RSpecExampleTraceHelpers
+  def fake_example(status:)
+    example = double("RSpec::Core::Example")
+    allow(example).to receive(:execution_result) { FakeExecutionResult.new(status: :failed) }
+    allow(example).to receive(:id) { "spec/fake/fake_spec[1:2:3]" }
+    allow(example).to receive(:full_description) { "this is a fake error full description" }
+    allow(example).to receive(:metadata) { Hash.new(shared_group_inclusion_backtrace: []) }
+    example
+  end
+
+  def fake_trace(a_example)
+    fake_trace = double("Buildkite::Collector::RSpecPlugin::Trace", example: a_example)
+    allow(fake_trace).to receive(:[]) { fake_trace }
+    allow(fake_trace).to receive(:example=)
+    allow(fake_trace).to receive(:failure_reason=)
+    allow(fake_trace).to receive(:failure_expanded=)
+    fake_trace
+  end
+end
+
+RSpec.configure do |config|
+  config.include RSpecExampleTraceHelpers
+end


### PR DESCRIPTION
The [reporter class](https://github.com/buildkite/rspec-buildkite-analytics/blob/f5636f04ba1c0ed1add2ef43d51a2216e5d15af7/lib/buildkite/collector/rspec_plugin/reporter.rb#L4) is under `RSpecPlugin`. Spotted when test failed:

<img width="1067" alt="CleanShot 2022-05-23 at 10 54 29@2x" src="https://user-images.githubusercontent.com/1000669/169728868-961b5939-daaf-4d04-a209-cd4209ea843a.png">

