### PR TITLE
Improve user experience running the collector

### DIFF
--- a/lib/buildkite/collector/socket_connection.rb
+++ b/lib/buildkite/collector/socket_connection.rb
@@ -76,7 +76,14 @@ module Buildkite::Collector
             @session.handle(self, data.data)
           end
         end
-      rescue EOFError, Errno::ECONNRESET => e
+      rescue EOFError => e
+        Buildkite::Collector.logger.warn("#{e}")
+        if @socket
+          Buildkite::Collector.logger.warn("attempting disconnected flow")
+          @session.disconnected(self)
+          disconnect
+        end
+      rescue Errno::ECONNRESET => e
         Buildkite::Collector.logger.error("#{e}")
         if @socket
           Buildkite::Collector.logger.error("attempting disconnected flow")


### PR DESCRIPTION
We hit an `EOFError` that happens frequently, and before we could fix that, use `WARN` instead of `ERROR` to improve user experience using our collector.

The specific `EOFError` was:

```
EOFError: end of file reached
lib/ruby/3.0.0/openssl/buffering.rb:148:in `sysread'
lib/ruby/3.0.0/openssl/buffering.rb:148:in `readpartial'
rspec-buildkite-analytics/lib/buildkite/collector/socket_connection.rb:73:in `block in initialize'
```

- [x] I’ve verified this works by manual testing